### PR TITLE
Fix skill category mapping

### DIFF
--- a/scripts/actor.js
+++ b/scripts/actor.js
@@ -57,8 +57,10 @@ export class WitchIronActor extends Actor {
     // Ensure all skill categories exist
     if (!systemData.skills.combat) systemData.skills.combat = {};
     if (!systemData.skills.physical) systemData.skills.physical = {};
-    if (!systemData.skills.social) systemData.skills.social = {};
+    if (!systemData.skills.quickness) systemData.skills.quickness = {};
+    if (!systemData.skills.finesse) systemData.skills.finesse = {};
     if (!systemData.skills.mental) systemData.skills.mental = {};
+    if (!systemData.skills.social) systemData.skills.social = {};
     
     // Combat skills
     if (!systemData.skills.combat.athletics) {
@@ -91,37 +93,29 @@ export class WitchIronActor extends Actor {
       systemData.skills.physical.skulk = { value: 0, ability: "agility", label: "Skulk", specializations: [] };
     }
     
-    // Add Social and Mental skills in the same pattern...
-    // Social skills
-    if (!systemData.skills.social.cunning) {
-      systemData.skills.social.cunning = { value: 0, ability: "quickness", label: "Cunning", specializations: [] };
+    // Quickness based skills
+    if (!systemData.skills.quickness.cunning) {
+      systemData.skills.quickness.cunning = { value: 0, ability: "quickness", label: "Cunning", specializations: [] };
     }
-    if (!systemData.skills.social.perception) {
-      systemData.skills.social.perception = { value: 0, ability: "quickness", label: "Perception", specializations: [] };
+    if (!systemData.skills.quickness.perception) {
+      systemData.skills.quickness.perception = { value: 0, ability: "quickness", label: "Perception", specializations: [] };
     }
-    if (!systemData.skills.social.ranged) {
-      systemData.skills.social.ranged = { value: 0, ability: "quickness", label: "Ranged", specializations: [] };
+    if (!systemData.skills.quickness.ranged) {
+      systemData.skills.quickness.ranged = { value: 0, ability: "quickness", label: "Ranged", specializations: [] };
     }
-    if (!systemData.skills.social.leadership) {
-      systemData.skills.social.leadership = { value: 0, ability: "personality", label: "Leadership", specializations: [] };
+
+    // Finesse based skills
+    if (!systemData.skills.finesse.art) {
+      systemData.skills.finesse.art = { value: 0, ability: "finesse", label: "Art", specializations: [] };
     }
-    if (!systemData.skills.social.carouse) {
-      systemData.skills.social.carouse = { value: 0, ability: "personality", label: "Carouse", specializations: [] };
+    if (!systemData.skills.finesse.operate) {
+      systemData.skills.finesse.operate = { value: 0, ability: "finesse", label: "Operate", specializations: [] };
     }
-    if (!systemData.skills.social.coerce) {
-      systemData.skills.social.coerce = { value: 0, ability: "personality", label: "Coerce", specializations: [] };
+    if (!systemData.skills.finesse.trade) {
+      systemData.skills.finesse.trade = { value: 0, ability: "finesse", label: "Trade", specializations: [] };
     }
-    
-    // Mental skills
-    if (!systemData.skills.mental.art) {
-      systemData.skills.mental.art = { value: 0, ability: "finesse", label: "Art", specializations: [] };
-    }
-    if (!systemData.skills.mental.operate) {
-      systemData.skills.mental.operate = { value: 0, ability: "finesse", label: "Operate", specializations: [] };
-    }
-    if (!systemData.skills.mental.trade) {
-      systemData.skills.mental.trade = { value: 0, ability: "finesse", label: "Trade", specializations: [] };
-    }
+
+    // Mental skills (Intellect and Willpower)
     if (!systemData.skills.mental.heal) {
       systemData.skills.mental.heal = { value: 0, ability: "intellect", label: "Heal", specializations: [] };
     }
@@ -140,9 +134,21 @@ export class WitchIronActor extends Actor {
     if (!systemData.skills.mental.husbandry) {
       systemData.skills.mental.husbandry = { value: 0, ability: "willpower", label: "Husbandry", specializations: [] };
     }
+
+    // Social skills
+    if (!systemData.skills.social.leadership) {
+      systemData.skills.social.leadership = { value: 0, ability: "personality", label: "Leadership", specializations: [] };
+    }
+    if (!systemData.skills.social.carouse) {
+      systemData.skills.social.carouse = { value: 0, ability: "personality", label: "Carouse", specializations: [] };
+    }
+    if (!systemData.skills.social.coerce) {
+      systemData.skills.social.coerce = { value: 0, ability: "personality", label: "Coerce", specializations: [] };
+    }
+    
     
     // Ensure all skills have the specializations array
-    for (const category of ["combat", "physical", "social", "mental"]) {
+    for (const category of ["combat", "physical", "quickness", "finesse", "mental", "social"]) {
       for (const skillKey in systemData.skills[category]) {
         if (!systemData.skills[category][skillKey].specializations) {
           systemData.skills[category][skillKey].specializations = [];
@@ -613,24 +619,28 @@ export class WitchIronActor extends Actor {
         ride: "agility",
         skulk: "agility"
       },
-      social: {
+      quickness: {
         cunning: "quickness",
         perception: "quickness",
-        ranged: "quickness",
-        leadership: "personality",
-        carouse: "personality",
-        coerce: "personality"
+        ranged: "quickness"
       },
-      mental: {
+      finesse: {
         art: "finesse",
         operate: "finesse",
-        trade: "finesse",
+        trade: "finesse"
+      },
+      mental: {
         heal: "intellect",
         research: "intellect",
         navigation: "intellect",
         steel: "willpower",
         survival: "willpower",
         husbandry: "willpower"
+      },
+      social: {
+        leadership: "personality",
+        carouse: "personality",
+        coerce: "personality"
       }
     };
     


### PR DESCRIPTION
## Summary
- initialize all skill categories used by character sheets
- map quickness and finesse skills to the correct categories
- update rollSkill attribute map to look up skills in those categories

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f5722ea60832d8cdddcec4ba48ce9