### PR TITLE
Fix missing skill categories

### DIFF
--- a/scripts/actor.js
+++ b/scripts/actor.js
@@ -57,6 +57,8 @@ export class WitchIronActor extends Actor {
     // Ensure all skill categories exist
     if (!systemData.skills.combat) systemData.skills.combat = {};
     if (!systemData.skills.physical) systemData.skills.physical = {};
+    if (!systemData.skills.quickness) systemData.skills.quickness = {};
+    if (!systemData.skills.finesse) systemData.skills.finesse = {};
     if (!systemData.skills.social) systemData.skills.social = {};
     if (!systemData.skills.mental) systemData.skills.mental = {};
     
@@ -91,17 +93,29 @@ export class WitchIronActor extends Actor {
       systemData.skills.physical.skulk = { value: 0, ability: "agility", label: "Skulk", specializations: [] };
     }
     
-    // Add Social and Mental skills in the same pattern...
+    // Quickness skills
+    if (!systemData.skills.quickness.cunning) {
+      systemData.skills.quickness.cunning = { value: 0, ability: "quickness", label: "Cunning", specializations: [] };
+    }
+    if (!systemData.skills.quickness.perception) {
+      systemData.skills.quickness.perception = { value: 0, ability: "quickness", label: "Perception", specializations: [] };
+    }
+    if (!systemData.skills.quickness.ranged) {
+      systemData.skills.quickness.ranged = { value: 0, ability: "quickness", label: "Ranged", specializations: [] };
+    }
+
+    // Finesse skills
+    if (!systemData.skills.finesse.art) {
+      systemData.skills.finesse.art = { value: 0, ability: "finesse", label: "Art", specializations: [] };
+    }
+    if (!systemData.skills.finesse.operate) {
+      systemData.skills.finesse.operate = { value: 0, ability: "finesse", label: "Operate", specializations: [] };
+    }
+    if (!systemData.skills.finesse.trade) {
+      systemData.skills.finesse.trade = { value: 0, ability: "finesse", label: "Trade", specializations: [] };
+    }
+
     // Social skills
-    if (!systemData.skills.social.cunning) {
-      systemData.skills.social.cunning = { value: 0, ability: "quickness", label: "Cunning", specializations: [] };
-    }
-    if (!systemData.skills.social.perception) {
-      systemData.skills.social.perception = { value: 0, ability: "quickness", label: "Perception", specializations: [] };
-    }
-    if (!systemData.skills.social.ranged) {
-      systemData.skills.social.ranged = { value: 0, ability: "quickness", label: "Ranged", specializations: [] };
-    }
     if (!systemData.skills.social.leadership) {
       systemData.skills.social.leadership = { value: 0, ability: "personality", label: "Leadership", specializations: [] };
     }
@@ -142,7 +156,7 @@ export class WitchIronActor extends Actor {
     }
     
     // Ensure all skills have the specializations array
-    for (const category of ["combat", "physical", "social", "mental"]) {
+    for (const category of ["combat", "physical", "quickness", "finesse", "social", "mental"]) {
       for (const skillKey in systemData.skills[category]) {
         if (!systemData.skills[category][skillKey].specializations) {
           systemData.skills[category][skillKey].specializations = [];
@@ -613,18 +627,22 @@ export class WitchIronActor extends Actor {
         ride: "agility",
         skulk: "agility"
       },
-      social: {
+      quickness: {
         cunning: "quickness",
         perception: "quickness",
-        ranged: "quickness",
+        ranged: "quickness"
+      },
+      finesse: {
+        art: "finesse",
+        operate: "finesse",
+        trade: "finesse"
+      },
+      social: {
         leadership: "personality",
         carouse: "personality",
         coerce: "personality"
       },
       mental: {
-        art: "finesse",
-        operate: "finesse",
-        trade: "finesse",
         heal: "intellect",
         research: "intellect",
         navigation: "intellect",


### PR DESCRIPTION
## Summary
- ensure quickness and finesse skill categories are initialized on actors
- map quickness and finesse skills correctly when rolling

## Testing
- `for f in scripts/*.js; do node -c "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_683f5729f078832d972965fa4a663282