### PR TITLE
Deduplicate Handlebars helpers

### DIFF
--- a/scripts/handlebars-helpers.js
+++ b/scripts/handlebars-helpers.js
@@ -1,0 +1,90 @@
+// Common Handlebars helpers used across the Witch Iron system
+export function registerCommonHandlebarsHelpers() {
+  // Register Handlebars helpers with proper block helper format
+  Handlebars.registerHelper('range', function(context, options) {
+    let output = "";
+    const data = Handlebars.createFrame(options.data);
+    for (let i = 0; i < context; i++) {
+      data.index = i;
+      output += options.fn(this, { data: data });
+    }
+    return output;
+  });
+
+  // Add Array constructor helper
+  Handlebars.registerHelper('Array', function(n) {
+    return [...Array(n).keys()];
+  });
+
+  // Add JSON stringify helper for debugging
+  Handlebars.registerHelper('json', function(context) {
+    return JSON.stringify(context, null, 2);
+  });
+
+  // Block helpers for comparison
+  Handlebars.registerHelper('eq', function(v1, v2, options) {
+    if (!options.fn) return v1 === v2;
+    if (v1 === v2) {
+      return options.fn(this);
+    }
+    return options.inverse ? options.inverse(this) : '';
+  });
+
+  Handlebars.registerHelper('lt', function(v1, v2, options) {
+    if (!options.fn) return v1 < v2;
+    if (v1 < v2) {
+      return options.fn(this);
+    }
+    return options.inverse ? options.inverse(this) : '';
+  });
+
+  Handlebars.registerHelper('gt', function(v1, v2, options) {
+    if (!options.fn) return v1 > v2;
+    if (v1 > v2) {
+      return options.fn(this);
+    }
+    return options.inverse ? options.inverse(this) : '';
+  });
+
+  Handlebars.registerHelper('le', function(v1, v2, options) {
+    if (!options.fn) return v1 <= v2;
+    if (v1 <= v2) {
+      return options.fn(this);
+    }
+    return options.inverse ? options.inverse(this) : '';
+  });
+
+  Handlebars.registerHelper('ge', function(v1, v2, options) {
+    if (!options.fn) return v1 >= v2;
+    if (v1 >= v2) {
+      return options.fn(this);
+    }
+    return options.inverse ? options.inverse(this) : '';
+  });
+
+  // Ensure gte alias exists for greater than or equal
+  Handlebars.registerHelper('gte', function(v1, v2, options) {
+    return Handlebars.helpers.ge(v1, v2, options);
+  });
+
+  // Simple expression helpers
+  Handlebars.registerHelper('add', function(v1, v2) {
+    return Number(v1) + Number(v2);
+  });
+
+  Handlebars.registerHelper('subtract', function(v1, v2) {
+    return Number(v1) - Number(v2);
+  });
+
+  Handlebars.registerHelper('multiply', function(v1, v2) {
+    return Number(v1) * Number(v2);
+  });
+
+  Handlebars.registerHelper('divide', function(v1, v2) {
+    return Number(v1) / Number(v2);
+  });
+
+  Handlebars.registerHelper('floor', function(v1) {
+    return Math.floor(Number(v1));
+  });
+}

--- a/scripts/quarrel.js
+++ b/scripts/quarrel.js
@@ -1,3 +1,5 @@
+import { registerCommonHandlebarsHelpers } from "./handlebars-helpers.js";
+
 /**
  * Quarrel system for Witch Iron
  * Implements contested checks with Net Hits results
@@ -1952,14 +1954,11 @@ function determineInjury(locationRoll, netDamage) {
  * Initialize the Handlebar helpers for quarrel messages
  */
 function initQuarrelHandlebarHelpers() {
+    // Ensure common helpers are available
+    registerCommonHandlebarsHelpers();
     Handlebars.registerHelper('actorName', function(actorId) {
         const actor = game.actors.get(actorId);
         return actor ? actor.name : "Unknown";
-    });
-    
-    // Helper to stringify an object to JSON
-    Handlebars.registerHelper('json', function(context) {
-        return JSON.stringify(context);
     });
     
     // Helper to concatenate strings
@@ -1971,15 +1970,6 @@ function initQuarrelHandlebarHelpers() {
     // Add helper for absolute values
     Handlebars.registerHelper('abs', function(num) {
         return Math.abs(Number(num));
-    });
-    
-    // Add comparison helpers
-    Handlebars.registerHelper('gt', function(a, b) {
-        return Number(a) > Number(b);
-    });
-    
-    Handlebars.registerHelper('lt', function(a, b) {
-        return Number(a) < Number(b);
     });
     
     // Add a more specific localization helper for quarrel outcomes

--- a/scripts/witch-iron.js
+++ b/scripts/witch-iron.js
@@ -14,6 +14,7 @@ import { WitchIronInjurySheet } from "./injury-sheet.js";
 import { initQuarrel, manualQuarrel } from "./quarrel.js";
 import { HitLocationSelector } from "./hit-location.js";
 import { InjuryTables } from "./injury-tables.js";
+import { registerCommonHandlebarsHelpers } from "./handlebars-helpers.js";
 
 // Define the system configuration object
 CONFIG.WITCH_IRON = {
@@ -70,117 +71,15 @@ CONFIG.WITCH_IRON = {
   }
 };
 
-// Register Handlebars helpers with proper block helper format
-Handlebars.registerHelper('range', function(context, options) {
-  let output = "";
-  const data = Handlebars.createFrame(options.data);
-  
-  for (let i = 0; i < context; i++) {
-    data.index = i;
-    output += options.fn(this, { data: data });
-  }
-  
-  return output;
-});
-
-// Add Array constructor helper
-Handlebars.registerHelper('Array', function(n) {
-  return [...Array(n).keys()];
-});
-
-// Add JSON stringify helper for debugging
-Handlebars.registerHelper('json', function(context) {
-  return JSON.stringify(context, null, 2);
-});
-
-// Block helpers for comparison
-Handlebars.registerHelper('eq', function(v1, v2, options) {
-  // When used as {{eq value1 value2}} without a block
-  if (!options.fn) return v1 === v2;
-  
-  // When used as {{#eq value1 value2}}...{{/eq}}
-  if (v1 === v2) {
-    return options.fn(this);
-  }
-  return options.inverse ? options.inverse(this) : '';
-});
-
-Handlebars.registerHelper('lt', function(v1, v2, options) {
-  // When used as {{lt value1 value2}} without a block
-  if (!options.fn) return v1 < v2;
-  
-  // When used as {{#lt value1 value2}}...{{/lt}}
-  if (v1 < v2) {
-    return options.fn(this);
-  }
-  return options.inverse ? options.inverse(this) : '';
-});
-
-Handlebars.registerHelper('gt', function(v1, v2, options) {
-  // When used as {{gt value1 value2}} without a block
-  if (!options.fn) return v1 > v2;
-  
-  // When used as {{#gt value1 value2}}...{{/gt}}
-  if (v1 > v2) {
-    return options.fn(this);
-  }
-  return options.inverse ? options.inverse(this) : '';
-});
-
-Handlebars.registerHelper('le', function(v1, v2, options) {
-  // When used as {{le value1 value2}} without a block
-  if (!options.fn) return v1 <= v2;
-  
-  // When used as {{#le value1 value2}}...{{/le}}
-  if (v1 <= v2) {
-    return options.fn(this);
-  }
-  return options.inverse ? options.inverse(this) : '';
-});
-
-Handlebars.registerHelper('ge', function(v1, v2, options) {
-  // When used as {{ge value1 value2}} without a block
-  if (!options.fn) return v1 >= v2;
-  
-  // When used as {{#ge value1 value2}}...{{/ge}}
-  if (v1 >= v2) {
-    return options.fn(this);
-  }
-  return options.inverse ? options.inverse(this) : '';
-});
-
-// Ensure gte alias exists for greater than or equal
-Handlebars.registerHelper('gte', function(v1, v2, options) {
-  return Handlebars.helpers.ge(v1, v2, options);
-});
-
-// Simple expression helpers
-Handlebars.registerHelper('add', function(v1, v2) {
-  return Number(v1) + Number(v2);
-});
-
-Handlebars.registerHelper('subtract', function(v1, v2) {
-  return Number(v1) - Number(v2);
-});
-
-Handlebars.registerHelper('multiply', function(v1, v2) {
-  return Number(v1) * Number(v2);
-});
-
-Handlebars.registerHelper('divide', function(v1, v2) {
-  return Number(v1) / Number(v2);
-});
-
-Handlebars.registerHelper('floor', function(v1) {
-  return Math.floor(Number(v1));
-});
-
 /* -------------------------------------------- */
 /*  Initialization                              */
 /* -------------------------------------------- */
 
 Hooks.once("init", function() {
   console.log("Witch Iron | Initializing Witch Iron System");
+
+  // Register shared Handlebars helpers
+  registerCommonHandlebarsHelpers();
   
   // Register system settings
   game.settings.register("witch-iron", "extendedRollVisibility", {


### PR DESCRIPTION
## Summary
- extract shared Handlebars helpers into `handlebars-helpers.js`
- import and register the helpers during system init
- rely on the shared helpers in the quarrel system

## Testing
- `node -c scripts/handlebars-helpers.js`
- `node -c scripts/witch-iron.js`
- `node -c scripts/quarrel.js`


------
https://chatgpt.com/codex/tasks/task_e_683f5813d428832d8a4ac71295950a54