### PR TITLE
Fix unlinked token cleanup for condition quarrels

### DIFF
--- a/scripts/quarrel.js
+++ b/scripts/quarrel.js
@@ -53,14 +53,13 @@ async function clearPhysicalConditions(actor) {
   // Update the base actor
   await actor.update(updates);
 
-  // Also update any unlinked token actors to keep sheets in sync
-  canvas.tokens.placeables
-    .filter(t => t.actor?.id === actor.id)
-    .forEach(t => {
-      if (!t.document.actorLink) {
-        t.actor.update(updates);
-      }
-    });
+  // Also update any unlinked tokens so their sheets stay in sync
+  const activeTokens = actor.getActiveTokens(true);
+  for (const token of activeTokens) {
+    if (!token.document.actorLink) {
+      await token.actor.update(updates);
+    }
+  }
 }
 
 class QuarrelTracker {

--- a/scripts/quarrel.js
+++ b/scripts/quarrel.js
@@ -38,8 +38,8 @@ const CONDITION_ICONS = {
 };
 
 /**
- * Reset Aflame, Bleed, and Poison conditions on the actor and any unlinked
- * tokens representing it.
+ * Reset the Aflame, Bleed, and Poison conditions on the given actor and update
+ * any unlinked tokens representing it.
  * @param {Actor} actor - The actor to update
  */
 async function clearPhysicalConditions(actor) {

--- a/scripts/quarrel.js
+++ b/scripts/quarrel.js
@@ -38,8 +38,8 @@ const CONDITION_ICONS = {
 };
 
 /**
- * Reset Aflame, Bleed, and Poison on an actor.
- * Also updates any unlinked tokens so their sheets stay in sync.
+ * Reset Aflame, Bleed, and Poison conditions on the actor and any unlinked
+ * tokens representing it.
  * @param {Actor} actor - The actor to update
  */
 async function clearPhysicalConditions(actor) {

--- a/scripts/quarrel.js
+++ b/scripts/quarrel.js
@@ -38,7 +38,8 @@ const CONDITION_ICONS = {
 };
 
 /**
- * Clear all physical affliction conditions on the actor
+ * Reset Aflame, Bleed, and Poison on an actor.
+ * Also updates any unlinked tokens so their sheets stay in sync.
  * @param {Actor} actor - The actor to update
  */
 async function clearPhysicalConditions(actor) {


### PR DESCRIPTION
## Summary
- ensure physical conditions reset on unlinked tokens by updating associated token actors

## Testing
- `node -c scripts/quarrel.js`

------
https://chatgpt.com/codex/tasks/task_e_683f9cd26a94832da3c54c8023b725f6