### PR TITLE
Automate stress/corruption condition quarrels

### DIFF
--- a/scripts/quarrel.js
+++ b/scripts/quarrel.js
@@ -567,6 +567,17 @@ class QuarrelTracker {
                 canvas.tokens.placeables
                   .filter(t => t.actor?.id === actor.id)
                   .forEach(t => t.actor?.toggleStatusEffect("dead", {active: true, overlay: true}));
+
+                // Additional effects for Stress and Corruption
+                if (['stress','corruption'].includes(result.condition)) {
+                    const wpPath = 'system.attributes.willpower.value';
+                    const currentWP = foundry.utils.getProperty(responderActor, wpPath) || 0;
+                    const updateData = {
+                        [wpPath]: Math.max(currentWP - 10, 0),
+                        [`system.conditions.${result.condition}.value`]: 0
+                    };
+                    await responderActor.update(updateData);
+                }
             }
             // Remove all conditions if actor wins
             else if (result.responderOutcome === 'Victory') {


### PR DESCRIPTION
## Summary
- import `quarrelTracker` in the main script
- trigger automatic Steel checks when Stress or Corruption hit multiples of three
- apply willpower loss and clearing when failing those quarrels

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_683f9d6b1948832dadd9347e12679f15