### PR TITLE
Fix clearing condition quarrel effects

### DIFF
--- a/scripts/quarrel.js
+++ b/scripts/quarrel.js
@@ -58,7 +58,15 @@ async function clearPhysicalConditions(actor) {
   for (const token of tokens) {
     if (token.actor) {
       await token.actor.update(updates);
+      if (token.actor.sheet) {
+        await token.actor.sheet.render(false);
+      }
     }
+  }
+
+  // Refresh the actor's own sheet if it's open
+  if (actor.sheet) {
+    await actor.sheet.render(false);
   }
 }
 


### PR DESCRIPTION
## Summary
- refresh actor sheet when physical afflictions are removed in a condition quarrel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fa9a12dd0832d90b00f661aae20a5