### PR TITLE
Refresh condition display when failing stress/corruption quarrels

### DIFF
--- a/scripts/quarrel.js
+++ b/scripts/quarrel.js
@@ -98,6 +98,31 @@ async function updateActorAndTokens(actor, updates) {
   }
 }
 
+/**
+ * Force refresh of a specific condition display on any open sheets
+ * @param {Actor} actor - The actor whose sheet should refresh
+ * @param {string} condition - Condition key (stress, corruption, etc.)
+ * @param {number} value - New numeric value to display
+ */
+function refreshConditionDisplay(actor, condition, value) {
+  if (!actor) return;
+
+  const updateHTML = (sheet) => {
+    if (!sheet?.rendered) return;
+    const html = sheet.element;
+    const displayElement = html.find(`.condition-row[data-condition="${condition}"] .cond-value`);
+    if (displayElement.length) {
+      displayElement.text(value);
+    }
+  };
+
+  updateHTML(actor.sheet);
+
+  for (const token of actor.getActiveTokens(true)) {
+    updateHTML(token.actor?.sheet);
+  }
+}
+
 class QuarrelTracker {
     constructor() {
         this.pendingQuarrels = new Map(); // Map of actor ID -> checkData
@@ -625,6 +650,7 @@ class QuarrelTracker {
                         [`system.conditions.${result.condition}.value`]: 0
                     };
                     await updateActorAndTokens(responderActor, updateData);
+                    refreshConditionDisplay(responderActor, result.condition, 0);
                 }
             }
             // Remove all conditions if actor wins


### PR DESCRIPTION
## Summary
- add helper to refresh a condition's value on any open sheets
- use helper after stress or corruption quarrel loss so the actor sheet shows 0

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fb655a1ac832da414c84aeea1857e