### PR TITLE
Fix condition quarrel sheet updates for tokens

### DIFF
--- a/scripts/monster-sheet.js
+++ b/scripts/monster-sheet.js
@@ -1078,7 +1078,7 @@ export class WitchIronMonsterSheet extends ActorSheet {
     console.log(`Witch Iron | Result Messages:`, resultMessages);
 
     // Setup the condition's side of the quarrel
-    const monsterToken = this.actor.getActiveTokens()[0] || null; // Get the first active token, or null
+    const monsterToken = this.actor.getActiveTokens(false)[0] || null; // Include unlinked tokens
 
     const customParameters = {
         actorId: this.actor.id,   // Add the source actor's ID

--- a/scripts/quarrel.js
+++ b/scripts/quarrel.js
@@ -54,7 +54,7 @@ async function clearPhysicalConditions(actor) {
   await actor.update(updates);
 
   // Also update any active tokens using this actor (covers unlinked monsters)
-  const tokens = actor.getActiveTokens(true);
+  const tokens = actor.getActiveTokens(false);
   for (const token of tokens) {
     if (token.actor) {
       await token.actor.update(updates);
@@ -82,7 +82,7 @@ async function updateActorAndTokens(actor, updates) {
   await actor.update(updates);
 
   // Update any active tokens derived from this actor
-  const tokens = actor.getActiveTokens(true);
+  const tokens = actor.getActiveTokens(false);
   for (const token of tokens) {
     if (token.actor) {
       await token.actor.update(updates);
@@ -118,7 +118,7 @@ function refreshConditionDisplay(actor, condition, value) {
 
   updateHTML(actor.sheet);
 
-  for (const token of actor.getActiveTokens(true)) {
+  for (const token of actor.getActiveTokens(false)) {
     updateHTML(token.actor?.sheet);
   }
 }

--- a/scripts/witch-iron.js
+++ b/scripts/witch-iron.js
@@ -212,7 +212,7 @@ Hooks.on("updateActor", async (actor) => {
   const pending = pendingConditionQuarrels.get(actor.id);
   if (!pending) return;
 
-  const token = actor.getActiveTokens()[0] || null;
+  const token = actor.getActiveTokens(false)[0] || null;
 
   if (pending.stress !== undefined) {
     await manualQuarrel({


### PR DESCRIPTION
## Summary
- update token refresh logic to include unlinked tokens
- pull active tokens from actors using `getActiveTokens(false)`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fb88f8aec832d9599261222ba5746