### PR TITLE
Fix monster stress/corruption quarrels

### DIFF
--- a/scripts/witch-iron.js
+++ b/scripts/witch-iron.js
@@ -229,7 +229,15 @@ Hooks.on("updateActor", async (actor) => {
       isConditionQuarrel: true,
       condition: "stress"
     }, token);
-    await actor.rollSkill("steel");
+
+    if (actor.type === "monster") {
+      await actor.rollMonsterCheck({
+        label: "Specialized Check",
+        additionalHits: actor.system.derived?.plusHits || 0
+      });
+    } else {
+      await actor.rollSkill("steel");
+    }
   }
 
   if (pending.corruption !== undefined) {
@@ -247,7 +255,15 @@ Hooks.on("updateActor", async (actor) => {
       isConditionQuarrel: true,
       condition: "corruption"
     }, token);
-    await actor.rollSkill("steel");
+
+    if (actor.type === "monster") {
+      await actor.rollMonsterCheck({
+        label: "Specialized Check",
+        additionalHits: actor.system.derived?.plusHits || 0
+      });
+    } else {
+      await actor.rollSkill("steel");
+    }
   }
 
   pendingConditionQuarrels.delete(actor.id);


### PR DESCRIPTION
## Summary
- ensure automatic Stress/Corruption quarrels roll a monster's Specialized check

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fbe70bcb0832d8a135d0566d393f6