### PR TITLE
Add condition modifiers dialog

### DIFF
--- a/scripts/actor-sheet.js
+++ b/scripts/actor-sheet.js
@@ -258,10 +258,24 @@ export class WitchIronActorSheet extends ActorSheet {
   _openRollDialog(title, rollCallback) {
     const content = `
       <form>
+        <h3>Target Number Modifiers</h3>
         <div class="form-group">
           <label>Situational Modifier</label>
           <input type="number" name="situationalMod" value="0" step="10" />
         </div>
+        <div class="form-group">
+          <label><input type="checkbox" name="condBlind"/> Blind Rating</label>
+          <input type="number" name="blindRating" value="0" min="0" />
+        </div>
+        <div class="form-group">
+          <label><input type="checkbox" name="condDeaf"/> Deaf Rating</label>
+          <input type="number" name="deafRating" value="0" min="0" />
+        </div>
+        <div class="form-group">
+          <label><input type="checkbox" name="condPain" checked/> Pain Rating</label>
+          <input type="number" name="painRating" value="0" min="0" />
+        </div>
+        <h3>Hits Modifiers</h3>
         <div class="form-group">
           <label>Additional +Hits</label>
           <input type="number" name="additionalHits" value="0" />
@@ -277,9 +291,22 @@ export class WitchIronActorSheet extends ActorSheet {
           label: "Roll",
           callback: html => {
             const form = html[0].querySelector("form");
+            let situationalMod = parseInt(form.situationalMod.value) || 0;
+            const additionalHits = parseInt(form.additionalHits.value) || 0;
+
+            if (form.condBlind.checked) {
+              situationalMod -= 10 * (parseInt(form.blindRating.value) || 0);
+            }
+            if (form.condDeaf.checked) {
+              situationalMod -= 10 * (parseInt(form.deafRating.value) || 0);
+            }
+            if (form.condPain.checked) {
+              situationalMod -= 10 * (parseInt(form.painRating.value) || 0);
+            }
+
             const opts = {
-              situationalMod: parseInt(form.situationalMod.value) || 0,
-              additionalHits: parseInt(form.additionalHits.value) || 0
+              situationalMod,
+              additionalHits
             };
             rollCallback(opts);
           }
@@ -307,10 +334,24 @@ export class WitchIronActorSheet extends ActorSheet {
           <label>Roll Label</label>
           <input type="text" name="label" value="Monster Check" />
         </div>
+        <h3>Target Number Modifiers</h3>
         <div class="form-group">
           <label>Situational Modifier</label>
           <input type="number" name="situationalMod" value="0" step="10" />
         </div>
+        <div class="form-group">
+          <label><input type="checkbox" name="condBlind"/> Blind Rating</label>
+          <input type="number" name="blindRating" value="0" min="0" />
+        </div>
+        <div class="form-group">
+          <label><input type="checkbox" name="condDeaf"/> Deaf Rating</label>
+          <input type="number" name="deafRating" value="0" min="0" />
+        </div>
+        <div class="form-group">
+          <label><input type="checkbox" name="condPain" checked/> Pain Rating</label>
+          <input type="number" name="painRating" value="0" min="0" />
+        </div>
+        <h3>Hits Modifiers</h3>
         <div class="form-group">
           <label>Additional +Hits</label>
           <input type="number" name="additionalHits" value="0" />
@@ -328,8 +369,18 @@ export class WitchIronActorSheet extends ActorSheet {
           callback: html => {
             const form = html.find("form")[0];
             const label = form.label.value;
-            const situationalMod = parseInt(form.situationalMod.value) || 0;
+            let situationalMod = parseInt(form.situationalMod.value) || 0;
             const additionalHits = parseInt(form.additionalHits.value) || 0;
+
+            if (form.condBlind.checked) {
+              situationalMod -= 10 * (parseInt(form.blindRating.value) || 0);
+            }
+            if (form.condDeaf.checked) {
+              situationalMod -= 10 * (parseInt(form.deafRating.value) || 0);
+            }
+            if (form.condPain.checked) {
+              situationalMod -= 10 * (parseInt(form.painRating.value) || 0);
+            }
             
             // Use the actor's rollMonsterCheck method which handles monster
             // checks. The previous call attempted to use a non-existent


### PR DESCRIPTION
## Summary
- allow selecting Blind/Deaf/Pain penalties when rolling
- include these condition options in monster rolls

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_683fc14bc8c0832da0f0d26d1910e22e