### PR TITLE
Add modifier dialog and condition fields

### DIFF
--- a/scripts/actor.js
+++ b/scripts/actor.js
@@ -240,6 +240,15 @@ export class WitchIronActor extends Actor {
     // Calculate literacy based on intellect
     const intellectValue = systemData.attributes.intellect?.value || 0;
     systemData.derivedFlags.canReadWrite = intellectValue >= 40;
+
+    // Initialize common conditions
+    const condList = ["blind", "deaf", "pain"];
+    if (!systemData.conditions) systemData.conditions = {};
+    for (const key of condList) {
+      if (!systemData.conditions[key] || typeof systemData.conditions[key]?.value !== 'number') {
+        systemData.conditions[key] = { value: 0 };
+      }
+    }
   }
 
   /**
@@ -499,7 +508,16 @@ export class WitchIronActor extends Actor {
     }
     
     // Initialize Conditions
-    const condNames = ["aflame","bleed","poison","corruption","stress"];
+    const condNames = [
+      "aflame",
+      "bleed",
+      "poison",
+      "corruption",
+      "stress",
+      "blind",
+      "deaf",
+      "pain"
+    ];
     if (!systemData.conditions) systemData.conditions = {};
     for (const key of condNames) {
       if (!systemData.conditions[key] || typeof systemData.conditions[key]?.value !== 'number') {

--- a/scripts/descendant-sheet.js
+++ b/scripts/descendant-sheet.js
@@ -1,4 +1,5 @@
 import { createItem } from "./utils.js";
+import { openModifierDialog } from "./modifier-dialog.js";
 
 /**
  * Descendant sheet class for the Witch Iron system
@@ -364,14 +365,11 @@ export class WitchIronDescendantSheet extends ActorSheet {
    * @param {Event} event   The originating click event
    * @private
    */
-  _onRollAttribute(event) {
+  async _onRollAttribute(event) {
     event.preventDefault();
-    const element = event.currentTarget;
-    const attribute = element.dataset.attribute;
-    // Call the actor's rollAttribute method if it exists
-    if (this.actor.rollAttribute) {
-      this.actor.rollAttribute(attribute);
-    }
+    const attribute = event.currentTarget.dataset.attribute;
+    const opts = await openModifierDialog(this.actor, { title: `Attribute Check: ${attribute}` });
+    if (opts) this.actor.rollAttribute(attribute, opts);
   }
 
   /**
@@ -379,12 +377,11 @@ export class WitchIronDescendantSheet extends ActorSheet {
    * @param {Event} event The originating click event
    * @private
    */
-  _onRollSkill(event) {
+  async _onRollSkill(event) {
     event.preventDefault();
-    const element = event.currentTarget;
-    const skillName = element.dataset.skill;
-    
-    this.actor.rollSkill(skillName);
+    const skillName = event.currentTarget.dataset.skill;
+    const opts = await openModifierDialog(this.actor, { title: `Skill Check: ${skillName}` });
+    if (opts) this.actor.rollSkill(skillName, opts);
   }
 
   /**

--- a/scripts/modifier-dialog.js
+++ b/scripts/modifier-dialog.js
@@ -1,0 +1,63 @@
+export async function openModifierDialog(actor, {title="Roll Modifiers", defaultHits=0}={}) {
+  const blind = actor?.system?.conditions?.blind?.value || 0;
+  const deaf = actor?.system?.conditions?.deaf?.value || 0;
+  const pain = actor?.system?.conditions?.pain?.value || 0;
+
+  return new Promise(resolve => {
+    const content = `
+      <form class="witch-iron modifier-dialog">
+        <h3>Difficulty Modifier</h3>
+        <div class="form-group">
+          <select name="difficulty">
+            <option value="40">Very Easy +40%</option>
+            <option value="20">Easy +20%</option>
+            <option value="0" selected>Normal +0%</option>
+            <option value="-20">Hard -20%</option>
+            <option value="-40">Very Hard -40%</option>
+          </select>
+        </div>
+        <h3>Condition Modifiers</h3>
+        <div class="form-group">
+          <label><input type="checkbox" name="useBlind" ${blind ? "checked" : ""}/> Blind</label>
+          <input type="number" name="blindRating" value="${blind}" min="0" />
+        </div>
+        <div class="form-group">
+          <label><input type="checkbox" name="useDeaf" ${deaf ? "checked" : ""}/> Deaf</label>
+          <input type="number" name="deafRating" value="${deaf}" min="0" />
+        </div>
+        <div class="form-group">
+          <label><input type="checkbox" name="usePain" checked/> Pain</label>
+          <input type="number" name="painRating" value="${pain}" min="0" />
+        </div>
+        <h3>Hits Modifiers</h3>
+        <div class="form-group">
+          <label>Additional +Hits</label>
+          <input type="number" name="additionalHits" value="${defaultHits}" />
+        </div>
+      </form>`;
+    const dialog = new Dialog({
+      title,
+      content,
+      buttons: {
+        roll: {
+          label: "Roll",
+          callback: html => {
+            const form = html[0].querySelector("form");
+            let situationalMod = Number(form.difficulty.value) || 0;
+            if (form.useBlind.checked) situationalMod -= 10 * (parseInt(form.blindRating.value) || 0);
+            if (form.useDeaf.checked) situationalMod -= 10 * (parseInt(form.deafRating.value) || 0);
+            if (form.usePain.checked) situationalMod -= 10 * (parseInt(form.painRating.value) || 0);
+            const additionalHits = parseInt(form.additionalHits.value) || 0;
+            resolve({ situationalMod, additionalHits });
+          }
+        },
+        cancel: {
+          label: "Cancel",
+          callback: () => resolve(null)
+        }
+      },
+      default: "roll"
+    }, { classes: ["witch-iron", "modifier-dialog"] });
+    dialog.render(true);
+  });
+}

--- a/scripts/monster-sheet.js
+++ b/scripts/monster-sheet.js
@@ -4,6 +4,7 @@
 // Import the quarrel API for non-combat condition checks
 import { manualQuarrel } from "./quarrel.js";
 import { createItem } from "./utils.js";
+import { openModifierDialog } from "./modifier-dialog.js";
 
 /**
  * Monster sheet class for the Witch Iron system
@@ -463,13 +464,18 @@ export class WitchIronMonsterSheet extends ActorSheet {
    * Roll a specialized check for the monster
    * @private
    */
-  _rollSpecializedCheck() {
-    // Call the actor's rollMonsterCheck method with appropriate options
-    if (this.actor.rollMonsterCheck) {
+  async _rollSpecializedCheck() {
+    if (!this.actor.rollMonsterCheck) return;
+    const defaultHits = this.actor.system.derived?.plusHits || 0;
+    const opts = await openModifierDialog(this.actor, {
+      title: "Specialized Check",
+      defaultHits
+    });
+    if (opts) {
       this.actor.rollMonsterCheck({
         label: "Specialized Check",
-        // Include the monster's +Hits bonus for specialized skills
-        additionalHits: this.actor.system.derived?.plusHits || 0
+        ...opts,
+        additionalHits: defaultHits + (opts.additionalHits || 0)
       });
     }
   }
@@ -478,13 +484,11 @@ export class WitchIronMonsterSheet extends ActorSheet {
    * Roll a general check for the monster
    * @private
    */
-  _rollGeneralCheck() {
-    // Call the actor's rollMonsterCheck method with no additional modifiers
-    if (this.actor.rollMonsterCheck) {
-      this.actor.rollMonsterCheck({
-        label: "General Check",
-        additionalHits: 0
-      });
+  async _rollGeneralCheck() {
+    if (!this.actor.rollMonsterCheck) return;
+    const opts = await openModifierDialog(this.actor, { title: "General Check" });
+    if (opts) {
+      this.actor.rollMonsterCheck({ label: "General Check", ...opts });
     }
   }
   
@@ -492,7 +496,7 @@ export class WitchIronMonsterSheet extends ActorSheet {
    * Roll an inept check for the monster
    * @private
    */
-  _rollIneptCheck() {
+  async _rollIneptCheck() {
     // Get the penalty based on HD
     const hdValue = this.actor.system.stats?.hitDice?.value || 1;
     
@@ -506,13 +510,13 @@ export class WitchIronMonsterSheet extends ActorSheet {
     
     const penalty = ineptPenalties[hdValue] || -10;
     
-    // Call the actor's rollMonsterCheck method with the penalty as situational modifier
-    if (this.actor.rollMonsterCheck) {
-      this.actor.rollMonsterCheck({
-        label: "Inept Check",
-        situationalMod: penalty,
-        additionalHits: 0
-      });
+    if (!this.actor.rollMonsterCheck) return;
+    const opts = await openModifierDialog(this.actor, {
+      title: "Inept Check",
+    });
+    if (opts) {
+      const situationalMod = (opts.situationalMod || 0) + penalty;
+      this.actor.rollMonsterCheck({ label: "Inept Check", ...opts, situationalMod });
     }
   }
 

--- a/styles/witch-iron.css
+++ b/styles/witch-iron.css
@@ -3660,3 +3660,20 @@ button.roll-skill:hover {
   height: auto;
   padding: 4px 8px;
 }
+/* -------------------------------------------------------------------------- */
+/* Modifier Dialog Styles */
+/* -------------------------------------------------------------------------- */
+.modifier-dialog .form-group {
+  display: flex;
+  align-items: center;
+  margin-bottom: 6px;
+}
+.modifier-dialog label {
+  flex: 1;
+  font-weight: bold;
+}
+.modifier-dialog input[type="number"],
+.modifier-dialog select {
+  width: 70px;
+  margin-left: 4px;
+}

--- a/templates/actors/monster-sheet.hbs
+++ b/templates/actors/monster-sheet.hbs
@@ -276,7 +276,7 @@
               <div class="condition-row flexrow" data-condition="{{key}}">
                 <button type="button" class="condition-name cond-quarrel">{{condition.label}}</button>
                 <button type="button" class="cond-minus"><i class="fas fa-minus"></i></button>
-                <span class="cond-value">{{condition.value}}</span>
+                <input type="number" class="cond-value" value="{{condition.value}}" min="0" />
                 <button type="button" class="cond-plus"><i class="fas fa-plus"></i></button>
               </div>
               {{/each}}


### PR DESCRIPTION
## Summary
- implement unified modifier dialog for rolls
- initialize Blind, Deaf and Pain conditions
- allow monsters to edit condition values
- apply modifier dialog to descendant and monster rolls
- style modifier dialogs

## Testing
- `npm test` *(fails: ENOENT could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68404e181afc832d8c419e5905345ce7