### PR TITLE
Add scrollable active effect selection

### DIFF
--- a/scripts/modifier-dialog.js
+++ b/scripts/modifier-dialog.js
@@ -3,6 +3,38 @@ export async function openModifierDialog(actor, {title="Roll Modifiers", default
   const deaf = actor?.system?.conditions?.deaf?.value || 0;
   const pain = actor?.system?.conditions?.pain?.value || 0;
 
+  // ------------------------------------------------------------
+  // Active Effect Parsing
+  // ------------------------------------------------------------
+  // Witch Iron uses Active Effects to represent miscellaneous bonuses
+  // or penalties that may apply to rolls. Each effect that should show
+  // up in the modifier dialog is expected to have a flag under
+  // `flags.witch-iron.modifier` with the following structure:
+  // {
+  //   type: "hits" | "target",  // what the modifier affects
+  //   value: Number             // amount applied when selected
+  // }
+  // Effects without this flag are ignored by the dialog but still
+  // apply normally through Foundry's standard Active Effect system.
+
+  const effects = actor?.effects?.contents || [];
+  const effectRows = effects.map(e => {
+    const mod = e.flags?.["witch-iron"]?.modifier;
+    if (!mod) return "";
+    const label = e.name ?? e.label ?? "Unnamed";
+    const val = Number(mod.value) || 0;
+    const dataAttr = mod.type === "hits"
+      ? `data-hits="${val}" data-target="0"`
+      : `data-hits="0" data-target="${val}"`;
+    const valueLabel = mod.type === "hits"
+      ? `${val >= 0 ? "+" : ""}${val} Hits`
+      : `${val >= 0 ? "+" : ""}${val} TN`;
+    return `<div class="form-group effect-row">
+              <label><input type="checkbox" name="effect-${e.id}" ${dataAttr}/> ${label}</label>
+              <span>${valueLabel}</span>
+            </div>`;
+  }).join("");
+
   return new Promise(resolve => {
     const content = `
       <form class="witch-iron modifier-dialog">
@@ -37,6 +69,7 @@ export async function openModifierDialog(actor, {title="Roll Modifiers", default
           <label>Additional +Hits</label>
           <input type="number" name="additionalHits" value="${defaultHits}" />
         </div>
+        ${effectRows ? `<h3>Active Effects</h3><div class="effects-list">${effectRows}</div>` : ''}
       </form>`;
     const dialog = new Dialog({
       title,
@@ -50,7 +83,16 @@ export async function openModifierDialog(actor, {title="Roll Modifiers", default
             if (parseInt(form.useBlind.value)) situationalMod -= 10 * (parseInt(form.blindRating.value) || 0);
             if (parseInt(form.useDeaf.value)) situationalMod -= 10 * (parseInt(form.deafRating.value) || 0);
             if (parseInt(form.usePain.value)) situationalMod -= 10 * (parseInt(form.painRating.value) || 0);
-            const additionalHits = parseInt(form.additionalHits.value) || 0;
+            let additionalHits = parseInt(form.additionalHits.value) || 0;
+
+            // Apply selected Active Effects
+            form.querySelectorAll('.effect-row input:checked').forEach(cb => {
+              const hits = Number(cb.dataset.hits) || 0;
+              const tgt = Number(cb.dataset.target) || 0;
+              additionalHits += hits;
+              situationalMod += tgt;
+            });
+
             resolve({ situationalMod, additionalHits });
           }
         },

--- a/styles/witch-iron.css
+++ b/styles/witch-iron.css
@@ -3693,3 +3693,18 @@ button.roll-skill:hover {
 .modifier-dialog .modifier-row.selected input[type="number"] {
   color: var(--color-background);
 }
+
+/* Active Effects list within the modifier dialog */
+.modifier-dialog .effects-list {
+  max-height: 120px;
+  overflow-y: auto;
+  border: 1px solid var(--color-border-light-primary);
+  padding: 4px;
+  margin-bottom: 6px;
+}
+
+.modifier-dialog .effect-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}


### PR DESCRIPTION
## Summary
- support active effects in roll modifier dialog
- style active effect list for scrolling

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840564dd400832d9c3a9fe96f2c8fea