### PR TITLE
Add example effect and hide zero-value conditions

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+This folder contains example documents for testing Witch Iron's features.
+
+`test-effect.json` defines a simple Active Effect with the `flags.witch-iron.modifier`
+structure. Import this into Foundry to verify the modifier dialog's Active
+Effect integration.

--- a/examples/test-effect.json
+++ b/examples/test-effect.json
@@ -1,0 +1,16 @@
+{
+  "_id": "test-effect-1",
+  "label": "Skill Specialization: Sneak",
+  "icon": "icons/svg/upgrade.svg",
+  "changes": [],
+  "disabled": false,
+  "duration": {},
+  "flags": {
+    "witch-iron": {
+      "modifier": {
+        "type": "hits",
+        "value": 1
+      }
+    }
+  }
+}

--- a/scripts/modifier-dialog.js
+++ b/scripts/modifier-dialog.js
@@ -3,6 +3,61 @@ export async function openModifierDialog(actor, {title="Roll Modifiers", default
   const deaf = actor?.system?.conditions?.deaf?.value || 0;
   const pain = actor?.system?.conditions?.pain?.value || 0;
 
+  // ------------------------------------------------------------
+  // Active Effect Parsing
+  // ------------------------------------------------------------
+  // Witch Iron uses Active Effects to represent miscellaneous bonuses
+  // or penalties that may apply to rolls. Each effect that should show
+  // up in the modifier dialog is expected to have a flag under
+  // `flags.witch-iron.modifier` with the following structure:
+  // {
+  //   type: "hits" | "target",  // what the modifier affects
+  //   value: Number             // amount applied when selected
+  // }
+  // Effects without this flag are ignored by the dialog but still
+  // apply normally through Foundry's standard Active Effect system.
+
+  const effects = actor?.effects?.contents || [];
+  const effectRows = effects.map(e => {
+    const mod = e.flags?.["witch-iron"]?.modifier;
+    if (!mod) return "";
+    const label = e.name ?? e.label ?? "Unnamed";
+    const val = Number(mod.value) || 0;
+    const dataAttr = mod.type === "hits"
+      ? `data-hits="${val}" data-target="0"`
+      : `data-hits="0" data-target="${val}"`;
+    const valueLabel = mod.type === "hits"
+      ? `${val >= 0 ? "+" : ""}${val} Hits`
+      : `${val >= 0 ? "+" : ""}${val} TN`;
+    return `<div class="form-group effect-row">
+              <label><input type="checkbox" name="effect-${e.id}" ${dataAttr}/> ${label}</label>
+              <span>${valueLabel}</span>
+            </div>`;
+  }).join("");
+
+  const conditionRows = [];
+  if (blind > 0) conditionRows.push(
+    `<div class="form-group modifier-row ${blind ? 'selected' : ''}" data-toggle="useBlind">
+       <label>Blind</label>
+       <input type="number" name="blindRating" value="${blind}" min="0" />
+       <input type="hidden" name="useBlind" value="${blind ? 1 : 0}">
+     </div>`
+  );
+  if (deaf > 0) conditionRows.push(
+    `<div class="form-group modifier-row ${deaf ? 'selected' : ''}" data-toggle="useDeaf">
+       <label>Deaf</label>
+       <input type="number" name="deafRating" value="${deaf}" min="0" />
+       <input type="hidden" name="useDeaf" value="${deaf ? 1 : 0}">
+     </div>`
+  );
+  if (pain > 0) conditionRows.push(
+    `<div class="form-group modifier-row selected" data-toggle="usePain">
+       <label>Pain</label>
+       <input type="number" name="painRating" value="${pain}" min="0" />
+       <input type="hidden" name="usePain" value="1">
+     </div>`
+  );
+
   return new Promise(resolve => {
     const content = `
       <form class="witch-iron modifier-dialog">
@@ -16,27 +71,13 @@ export async function openModifierDialog(actor, {title="Roll Modifiers", default
             <option value="-40">Very Hard -40%</option>
           </select>
         </div>
-        <h3>Condition Modifiers</h3>
-        <div class="form-group modifier-row ${blind ? 'selected' : ''}" data-toggle="useBlind">
-          <label>Blind</label>
-          <input type="number" name="blindRating" value="${blind}" min="0" />
-          <input type="hidden" name="useBlind" value="${blind ? 1 : 0}">
-        </div>
-        <div class="form-group modifier-row ${deaf ? 'selected' : ''}" data-toggle="useDeaf">
-          <label>Deaf</label>
-          <input type="number" name="deafRating" value="${deaf}" min="0" />
-          <input type="hidden" name="useDeaf" value="${deaf ? 1 : 0}">
-        </div>
-        <div class="form-group modifier-row selected" data-toggle="usePain">
-          <label>Pain</label>
-          <input type="number" name="painRating" value="${pain}" min="0" />
-          <input type="hidden" name="usePain" value="1">
-        </div>
+        ${conditionRows.length ? `<h3>Condition Modifiers</h3>${conditionRows.join('')}` : ''}
         <h3>Hits Modifiers</h3>
         <div class="form-group">
           <label>Additional +Hits</label>
           <input type="number" name="additionalHits" value="${defaultHits}" />
         </div>
+        ${effectRows ? `<h3>Active Effects</h3><div class="effects-list">${effectRows}</div>` : ''}
       </form>`;
     const dialog = new Dialog({
       title,
@@ -47,10 +88,19 @@ export async function openModifierDialog(actor, {title="Roll Modifiers", default
           callback: html => {
             const form = html[0].querySelector("form");
             let situationalMod = Number(form.difficulty.value) || 0;
-            if (parseInt(form.useBlind.value)) situationalMod -= 10 * (parseInt(form.blindRating.value) || 0);
-            if (parseInt(form.useDeaf.value)) situationalMod -= 10 * (parseInt(form.deafRating.value) || 0);
-            if (parseInt(form.usePain.value)) situationalMod -= 10 * (parseInt(form.painRating.value) || 0);
-            const additionalHits = parseInt(form.additionalHits.value) || 0;
+            if (parseInt(form.useBlind?.value)) situationalMod -= 10 * (parseInt(form.blindRating?.value) || 0);
+            if (parseInt(form.useDeaf?.value)) situationalMod -= 10 * (parseInt(form.deafRating?.value) || 0);
+            if (parseInt(form.usePain?.value)) situationalMod -= 10 * (parseInt(form.painRating?.value) || 0);
+            let additionalHits = parseInt(form.additionalHits.value) || 0;
+
+            // Apply selected Active Effects
+            form.querySelectorAll('.effect-row input:checked').forEach(cb => {
+              const hits = Number(cb.dataset.hits) || 0;
+              const tgt = Number(cb.dataset.target) || 0;
+              additionalHits += hits;
+              situationalMod += tgt;
+            });
+
             resolve({ situationalMod, additionalHits });
           }
         },

--- a/styles/witch-iron.css
+++ b/styles/witch-iron.css
@@ -3693,3 +3693,18 @@ button.roll-skill:hover {
 .modifier-dialog .modifier-row.selected input[type="number"] {
   color: var(--color-background);
 }
+
+/* Active Effects list within the modifier dialog */
+.modifier-dialog .effects-list {
+  max-height: 120px;
+  overflow-y: auto;
+  border: 1px solid var(--color-border-light-primary);
+  padding: 4px;
+  margin-bottom: 6px;
+}
+
+.modifier-dialog .effect-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}


### PR DESCRIPTION
## Summary
- hide Blind/Deaf/Pain rows when rating is 0
- guard condition values in modifier dialog
- provide `examples/test-effect.json` for verifying active effects

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840564dd400832d9c3a9fe96f2c8fea