### PR TITLE
Handle missing condition modifiers

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,6 @@
+# Example Active Effect
+
+This folder contains sample data for testing Active Effects in Witch Iron.
+
+`test-effect.json` shows how to structure the `flags.witch-iron.modifier` object so that the effect appears in the modifier dialog.
+

--- a/examples/test-effect.json
+++ b/examples/test-effect.json
@@ -1,0 +1,16 @@
+{
+  "_id": "example-effect",
+  "name": "Test Accuracy Bonus",
+  "icon": "icons/svg/upgrade.svg",
+  "changes": [],
+  "duration": {},
+  "disabled": false,
+  "flags": {
+    "witch-iron": {
+      "modifier": {
+        "type": "target",
+        "value": 10
+      }
+    }
+  }
+}

--- a/scripts/modifier-dialog.js
+++ b/scripts/modifier-dialog.js
@@ -35,6 +35,32 @@ export async function openModifierDialog(actor, {title="Roll Modifiers", default
             </div>`;
   }).join("");
 
+  const conditionRows = [];
+  if (blind > 0) {
+    conditionRows.push(`
+        <div class="form-group modifier-row ${blind ? 'selected' : ''}" data-toggle="useBlind">
+          <label>Blind</label>
+          <input type="number" name="blindRating" value="${blind}" min="0" />
+          <input type="hidden" name="useBlind" value="${blind ? 1 : 0}">
+        </div>`);
+  }
+  if (deaf > 0) {
+    conditionRows.push(`
+        <div class="form-group modifier-row ${deaf ? 'selected' : ''}" data-toggle="useDeaf">
+          <label>Deaf</label>
+          <input type="number" name="deafRating" value="${deaf}" min="0" />
+          <input type="hidden" name="useDeaf" value="${deaf ? 1 : 0}">
+        </div>`);
+  }
+  if (pain > 0) {
+    conditionRows.push(`
+        <div class="form-group modifier-row selected" data-toggle="usePain">
+          <label>Pain</label>
+          <input type="number" name="painRating" value="${pain}" min="0" />
+          <input type="hidden" name="usePain" value="1">
+        </div>`);
+  }
+
   return new Promise(resolve => {
     const content = `
       <form class="witch-iron modifier-dialog">
@@ -48,22 +74,7 @@ export async function openModifierDialog(actor, {title="Roll Modifiers", default
             <option value="-40">Very Hard -40%</option>
           </select>
         </div>
-        <h3>Condition Modifiers</h3>
-        <div class="form-group modifier-row ${blind ? 'selected' : ''}" data-toggle="useBlind">
-          <label>Blind</label>
-          <input type="number" name="blindRating" value="${blind}" min="0" />
-          <input type="hidden" name="useBlind" value="${blind ? 1 : 0}">
-        </div>
-        <div class="form-group modifier-row ${deaf ? 'selected' : ''}" data-toggle="useDeaf">
-          <label>Deaf</label>
-          <input type="number" name="deafRating" value="${deaf}" min="0" />
-          <input type="hidden" name="useDeaf" value="${deaf ? 1 : 0}">
-        </div>
-        <div class="form-group modifier-row selected" data-toggle="usePain">
-          <label>Pain</label>
-          <input type="number" name="painRating" value="${pain}" min="0" />
-          <input type="hidden" name="usePain" value="1">
-        </div>
+        ${conditionRows.length ? `<h3>Condition Modifiers</h3>${conditionRows.join('')}` : ''}
         <h3>Hits Modifiers</h3>
         <div class="form-group">
           <label>Additional +Hits</label>
@@ -80,9 +91,15 @@ export async function openModifierDialog(actor, {title="Roll Modifiers", default
           callback: html => {
             const form = html[0].querySelector("form");
             let situationalMod = Number(form.difficulty.value) || 0;
-            if (parseInt(form.useBlind.value)) situationalMod -= 10 * (parseInt(form.blindRating.value) || 0);
-            if (parseInt(form.useDeaf.value)) situationalMod -= 10 * (parseInt(form.deafRating.value) || 0);
-            if (parseInt(form.usePain.value)) situationalMod -= 10 * (parseInt(form.painRating.value) || 0);
+            const useBlind = form.querySelector('[name="useBlind"]')?.value;
+            const blindRating = form.querySelector('[name="blindRating"]')?.value;
+            if (parseInt(useBlind)) situationalMod -= 10 * (parseInt(blindRating) || 0);
+            const useDeaf = form.querySelector('[name="useDeaf"]')?.value;
+            const deafRating = form.querySelector('[name="deafRating"]')?.value;
+            if (parseInt(useDeaf)) situationalMod -= 10 * (parseInt(deafRating) || 0);
+            const usePain = form.querySelector('[name="usePain"]')?.value;
+            const painRating = form.querySelector('[name="painRating"]')?.value;
+            if (parseInt(usePain)) situationalMod -= 10 * (parseInt(painRating) || 0);
             let additionalHits = parseInt(form.additionalHits.value) || 0;
 
             // Apply selected Active Effects

--- a/scripts/monster-sheet.js
+++ b/scripts/monster-sheet.js
@@ -1049,6 +1049,40 @@ export class WitchIronMonsterSheet extends ActorSheet {
     let skillName = "";
     let resultMessages = {};
 
+    if (["blind", "deaf", "pain"].includes(conditionName)) {
+      rating = actor.system.conditions[conditionName]?.value || 0;
+      const condLabel = this.capitalize(conditionName);
+      const penalty = rating * 10;
+      const checkType = conditionName === "blind" ? "Sight-based Checks" :
+                        conditionName === "deaf" ? "Hearing & Speech-based Checks" :
+                        "All Checks";
+      const removal = conditionName === "blind" ? "Cleaning out the eyes" :
+                      conditionName === "deaf" ? "Removing blockage" :
+                      "A form of painkiller";
+      const icon = conditionName === "blind" ? "fa-eye-slash" :
+                   conditionName === "deaf" ? "fa-deaf" :
+                   "fa-user-injured";
+      const content = `
+        <div class="witch-iron chat-card condition-card">
+          <header class="card-header">
+            <i class="fas ${icon}"></i>
+            <h3>${condLabel}</h3>
+          </header>
+          <div class="card-content">
+            <p><strong>${actor.name}</strong> is suffering from ${condLabel} (Rating ${rating}).</p>
+            <p>Retina Overload, Ringing in Ears &amp; Agony. This Condition inflicts a <strong>${penalty}%</strong> Check penalty. Passively reduce by one each hour.</p>
+            <p><strong>Impairs:</strong> ${checkType}.</p>
+            <p><strong>Removed by:</strong> ${removal}.</p>
+          </div>
+        </div>`;
+      const chatData = {
+        user: game.user.id,
+        speaker: ChatMessage.getSpeaker({ actor }),
+        content
+      };
+      return ChatMessage.create(chatData);
+    }
+
     if (["aflame", "bleed", "poison"].includes(conditionName)) {
       skillName = "Hardship";
       rating = ["aflame", "bleed", "poison"].reduce((sum, c) => sum + (actor.system.conditions[c]?.value || 0), 0);

--- a/styles/condition-card.css
+++ b/styles/condition-card.css
@@ -1,0 +1,8 @@
+.witch-iron.chat-card.condition-card {
+  /* Base chat card styles inherited */
+}
+
+.witch-iron.chat-card.condition-card .card-header i {
+  font-size: 1.2em;
+}
+

--- a/system.json
+++ b/system.json
@@ -21,7 +21,8 @@
     "styles/witch-iron.css",
     "styles/combat-card.css",
     "styles/hit-location.css",
-    "styles/injury-card.css"
+    "styles/injury-card.css",
+    "styles/condition-card.css"
   ],
   "packs": [
     {


### PR DESCRIPTION
## Summary
- hide Blind, Deaf and Pain rows when the actor has zero rating
- guard against missing fields when reading the dialog
- provide example Active Effect data for testing
- restyle condition info chat card to match other Witch Iron cards

## Testing
- `node --check scripts/modifier-dialog.js`
- `node --check scripts/monster-sheet.js`


------
https://chatgpt.com/codex/tasks/task_e_68405d351da8832da5d90834558c777c