### PR TITLE
Style condition info cards

### DIFF
--- a/scripts/monster-sheet.js
+++ b/scripts/monster-sheet.js
@@ -1059,13 +1059,27 @@ export class WitchIronMonsterSheet extends ActorSheet {
       const removal = conditionName === "blind" ? "Cleaning out the eyes" :
                       conditionName === "deaf" ? "Removing blockage" :
                       "A form of painkiller";
+
+      const iconMap = {
+        blind: "fa-eye-slash",
+        deaf: "fa-ear-deaf",
+        pain: "fa-hand-holding-medical"
+      };
+      const iconClass = iconMap[conditionName] || "fa-info-circle";
+
       const content = `
-        <div class="witch-iron condition-info">
-          <p><strong>${actor.name}</strong> is suffering from ${condLabel} (Rating ${rating}).</p>
-          <p>Retina Overload, Ringing in Ears &amp; Agony. This Condition inflicts a <strong>${penalty}%</strong> Check penalty. Passively reduce by one each hour.</p>
-          <p><strong>Impairs:</strong> ${checkType}.</p>
-          <p><strong>Removed by:</strong> ${removal}.</p>
+        <div class="witch-iron chat-card condition-card">
+          <div class="card-header">
+            <i class="fas ${iconClass}"></i>
+            <h3>${actor.name} - ${condLabel}</h3>
+          </div>
+          <div class="card-content">
+            <p>Retina Overload, Ringing in Ears &amp; Agony. This Condition inflicts a <strong>${penalty}%</strong> Check penalty. Passively reduce by one each hour.</p>
+            <p><strong>Impairs:</strong> ${checkType}.</p>
+            <p><strong>Removed by:</strong> ${removal}.</p>
+          </div>
         </div>`;
+
       const chatData = {
         user: game.user.id,
         speaker: ChatMessage.getSpeaker({ actor }),

--- a/scripts/quarrel.js
+++ b/scripts/quarrel.js
@@ -34,7 +34,10 @@ const CONDITION_ICONS = {
   bleed: "icons/svg/blood.svg",
   poison: "icons/svg/poison.svg",
   stress: "icons/svg/burst.svg",
-  corruption: "icons/svg/bone.svg"
+  corruption: "icons/svg/bone.svg",
+  blind: "icons/svg/eye.svg",
+  deaf: "icons/svg/deaf.svg",
+  pain: "icons/svg/daze.svg"
 };
 
 /**

--- a/styles/condition-card.css
+++ b/styles/condition-card.css
@@ -1,0 +1,33 @@
+/* Condition Card Styles */
+.witch-iron.chat-card.condition-card {
+  border: 1px solid var(--color-border-light);
+  border-radius: 6px;
+  margin: 0;
+  background: #fff;
+  color: var(--color-text-dark);
+  font-family: 'Gentium Book', serif;
+  overflow: hidden;
+}
+
+.witch-iron.chat-card.condition-card .card-header {
+  background: var(--color-accent);
+  color: #f5e8d2;
+  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.witch-iron.chat-card.condition-card .card-header i {
+  font-size: 1.4em;
+}
+
+.witch-iron.chat-card.condition-card .card-header h3 {
+  margin: 0;
+  font-size: 1.2em;
+  font-weight: bold;
+}
+
+.witch-iron.chat-card.condition-card .card-content {
+  padding: 12px;
+}

--- a/system.json
+++ b/system.json
@@ -21,7 +21,8 @@
     "styles/witch-iron.css",
     "styles/combat-card.css",
     "styles/hit-location.css",
-    "styles/injury-card.css"
+    "styles/injury-card.css",
+    "styles/condition-card.css"
   ],
   "packs": [
     {


### PR DESCRIPTION
## Summary
- add dedicated styles for condition chat cards
- use chat card layout for Blind, Deaf and Pain info
- support icons for Blind, Deaf and Pain
- register new stylesheet in `system.json`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840646f3f84832d8325851abf4301d2