### PR TITLE
Implement mob rules for monsters

### DIFF
--- a/templates/actors/monster-sheet.hbs
+++ b/templates/actors/monster-sheet.hbs
@@ -204,6 +204,14 @@
                   <label>Number of Bodies</label>
                   <input type="number" name="system.mob.bodies.value" value="{{system.mob.bodies.value}}">
                 </div>
+                <div class="form-group">
+                  <label>Mob Scale</label>
+                  <span>{{system.derived.mobScale}}</span>
+                </div>
+                <div class="form-group">
+                  <label>Mob Attacks</label>
+                  <span>{{system.derived.mobAttacks}}</span>
+                </div>
               {{/if}}
             </div>
           </div>

--- a/templates/chat/mob-injury-message.hbs
+++ b/templates/chat/mob-injury-message.hbs
@@ -1,0 +1,15 @@
+<div class="witch-iron chat-card mob-injury-card">
+  <header class="card-header">
+    <h3>Mob Casualties</h3>
+  </header>
+  <div class="card-content">
+    <div class="mob-info">
+      <strong>{{defender}}</strong> loses <strong>{{killed}}</strong> bodies.
+      {{#if remaining}}
+        <span>{{remaining}} bodies remain.</span>
+      {{else}}
+        <span>The mob has been destroyed.</span>
+      {{/if}}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add a chat template for mob casualties
- compute mob body loss and generate casualties chat message
- display mob scale and attack count on monster sheet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68406ad153ac832d98b839d268473b2f