### PR TITLE
Implement mob rout checks

### DIFF
--- a/templates/actors/monster-sheet.hbs
+++ b/templates/actors/monster-sheet.hbs
@@ -204,6 +204,14 @@
                   <label>Number of Bodies</label>
                   <input type="number" name="system.mob.bodies.value" value="{{system.mob.bodies.value}}">
                 </div>
+                <div class="form-group">
+                  <label>Mob Scale</label>
+                  <span>{{system.derived.mobScale}}</span>
+                </div>
+                <div class="form-group">
+                  <label>Mob Attacks</label>
+                  <span>{{system.derived.mobAttacks}}</span>
+                </div>
               {{/if}}
             </div>
           </div>

--- a/templates/chat/mob-injury-message.hbs
+++ b/templates/chat/mob-injury-message.hbs
@@ -1,0 +1,15 @@
+<div class="witch-iron chat-card mob-injury-card">
+  <header class="card-header">
+    <h3>Mob Casualties</h3>
+  </header>
+  <div class="card-content">
+    <div class="mob-info">
+      <strong>{{defender}}</strong> loses <strong>{{killed}}</strong> bodies.
+      {{#if remaining}}
+        <span>{{remaining}} bodies remain.</span>
+      {{else}}
+        <span>The mob has been destroyed.</span>
+      {{/if}}
+    </div>
+  </div>
+</div>

--- a/templates/chat/mob-loss-message.hbs
+++ b/templates/chat/mob-loss-message.hbs
@@ -1,0 +1,12 @@
+<div class="witch-iron chat-card mob-loss-card">
+  <header class="card-header">
+    <h3>Mob Losses</h3>
+  </header>
+  <div class="card-content">
+    {{#if success}}
+      <p>{{mob}} holds together despite heavy losses.</p>
+    {{else}}
+      <p>{{mob}} routs and is destroyed!</p>
+    {{/if}}
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- expand mob casualty handling to trigger rout check on scale loss
- add dialog to select leader for leadership roll
- create mob loss message template

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68406ad153ac832d98b839d268473b2f