### PR TITLE
Enhance mob casualty messaging

### DIFF
--- a/scripts/hit-location.js
+++ b/scripts/hit-location.js
@@ -104,6 +104,7 @@ async function handleMobScaleRout(mobActor, oldBodies, newBodies) {
                         const target = mobActor.system.derived?.abilityScore || 0;
                         const success = await performRoutRoll(mobActor, "Steel Check", target);
                         if (!success) await mobActor.update({"system.mob.bodies.value": 0});
+                        await createRoutResultMessage(mobActor.name, success);
                         resolve();
                     }
                 },
@@ -128,12 +129,27 @@ async function handleMobScaleRout(mobActor, oldBodies, newBodies) {
                             success = await performRoutRoll(mobActor, "Steel Check", target);
                         }
                         if (!success) await mobActor.update({"system.mob.bodies.value": 0});
+                        await createRoutResultMessage(mobActor.name, success);
                         resolve();
                     }
                 }
             },
             default: "mob"
-        }).render(true);
+        }, { classes: ["rout-check-dialog"] }).render(true);
+    });
+}
+
+async function createRoutResultMessage(actorName, success) {
+    const content = await renderTemplate(
+        "systems/witch-iron/templates/chat/rout-result.hbs",
+        { actor: actorName, success }
+    );
+    await ChatMessage.create({
+        user: game.user.id,
+        content,
+        speaker: ChatMessage.getSpeaker(),
+        flavor: "Rout Result",
+        flags: { "witch-iron": { messageType: "rout-result" } }
     });
 }
 
@@ -531,13 +547,20 @@ export class HitLocationSelector {
                 await defenderActor.update({ "system.mob.bodies.value": remainingBodies });
             }
 
+            const oldScale = getMobScale(currentBodies);
+            const newScale = getMobScale(remainingBodies);
+            const scaleChange = scaleRank(newScale) < scaleRank(oldScale);
+
             const mobContent = await renderTemplate(
                 "systems/witch-iron/templates/chat/mob-injury-message.hbs",
                 {
                     attacker: combatData.attacker,
                     defender: combatData.defender,
                     killed: bodiesKilled,
-                    remaining: remainingBodies
+                    remaining: remainingBodies,
+                    damage: netDamage,
+                    scaleChange: scaleChange,
+                    newScale: newScale
                 }
             );
 
@@ -554,7 +577,8 @@ export class HitLocationSelector {
                 }
             });
 
-            // Check if mob scale has been reduced and possibly trigger a rout check
+            setTimeout(() => attachMobInjuryHandlers(mobMessage.id), 50);
+
             await handleMobScaleRout(defenderActor, currentBodies, remainingBodies);
 
             return mobMessage;
@@ -2625,6 +2649,27 @@ function attachInjuryMessageHandlers(messageId) {
     });
 }
 
+function attachMobInjuryHandlers(messageId) {
+    const messageElement = document.querySelector(`.message[data-message-id="${messageId}"]`);
+    if (!messageElement) return;
+    const toggle = messageElement.querySelector('.mob-details-toggle');
+    if (!toggle) return;
+    const content = messageElement.querySelector('.mob-details');
+    const icon = toggle.querySelector('i');
+    toggle.addEventListener('click', ev => {
+        ev.preventDefault();
+        if (!content) return;
+        const hidden = content.classList.contains('hidden');
+        if (hidden) {
+            content.classList.remove('hidden');
+            if (icon) icon.classList.replace('fa-chevron-down','fa-chevron-up');
+        } else {
+            content.classList.add('hidden');
+            if (icon) icon.classList.replace('fa-chevron-up','fa-chevron-down');
+        }
+    });
+}
+
 /**
  * Update battle wear buttons enabled/disabled state
  * @param {HTMLElement} messageElement The message element
@@ -3037,6 +3082,9 @@ async function updateActorBattleWear(message, attackerWear, defenderWear) {
 Hooks.on("renderChatMessage", (message, html, data) => {
     // Check if this is an injury message
     const messageType = message.getFlag("witch-iron", "messageType");
+    if (messageType === "mob-injury") {
+        setTimeout(() => attachMobInjuryHandlers(message.id), 20);
+    }
     if (messageType === "injury" || messageType === "deflection") {
         console.log(`Detected injury message being rendered: ${message.id}`);
         

--- a/styles/mob-card.css
+++ b/styles/mob-card.css
@@ -1,0 +1,148 @@
+/* Mob Casualty and Rout Styles */
+.witch-iron.chat-card.mob-injury-card {
+  border: 1px solid var(--color-border-light);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--color-text-dark);
+  font-family: 'Gentium Book', serif;
+  overflow: hidden;
+  margin-bottom: 5px;
+}
+
+.witch-iron.chat-card.mob-injury-card .card-header {
+  background: var(--color-accent);
+  color: #f5e8d2;
+  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.witch-iron.chat-card.mob-injury-card .card-header i {
+  font-size: 1.2em;
+}
+
+.witch-iron.chat-card.mob-injury-card .card-header h3 {
+  margin: 0;
+  font-size: 1.2em;
+  font-weight: bold;
+}
+
+.witch-iron.chat-card.mob-injury-card .card-content {
+  padding: 12px;
+}
+
+.witch-iron.chat-card.mob-injury-card .mob-summary-number {
+  text-align: center;
+  font-size: 1.6em;
+  font-weight: bold;
+}
+
+.witch-iron.chat-card.mob-injury-card .mob-summary-text,
+.witch-iron.chat-card.mob-injury-card .mob-remaining {
+  text-align: center;
+  font-size: 0.9em;
+  margin-bottom: 2px;
+}
+
+.witch-iron.chat-card.mob-injury-card .scale-change {
+  text-align: center;
+  color: var(--color-accent);
+  font-weight: bold;
+  margin-top: 4px;
+}
+
+.witch-iron.chat-card.mob-injury-card .collapsible-section {
+  margin-top: 6px;
+  border: 1px solid rgba(123,45,38,0.2);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.witch-iron.chat-card.mob-injury-card .section-header {
+  display: flex;
+  align-items: center;
+  padding: 5px 10px;
+  background: rgba(123,45,38,0.1);
+  cursor: pointer;
+}
+
+.witch-iron.chat-card.mob-injury-card .section-header i {
+  margin-right: 8px;
+  transition: transform 0.3s;
+}
+
+.witch-iron.chat-card.mob-injury-card .section-header.open i {
+  transform: rotate(180deg);
+}
+
+.witch-iron.chat-card.mob-injury-card .section-header h4 {
+  margin: 0;
+  font-size: 1em;
+}
+
+.witch-iron.chat-card.mob-injury-card .section-content {
+  padding: 8px 10px;
+  background: rgba(0,0,0,0.02);
+}
+
+.witch-iron.chat-card.mob-injury-card .section-content.hidden {
+  display: none;
+}
+
+.witch-iron.chat-card.mob-injury-card .detail-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px 10px;
+}
+
+.witch-iron.chat-card.mob-injury-card .detail-item {
+  display: flex;
+  justify-content: space-between;
+}
+
+.witch-iron.chat-card.mob-injury-card .detail-item .label {
+  font-weight: bold;
+  color: var(--color-text-muted);
+}
+
+.witch-iron.chat-card.mob-injury-card .detail-item .value {
+  color: var(--color-text-dark);
+}
+
+.witch-iron.chat-card.rout-result-card {
+  border: 1px solid var(--color-border-light);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--color-text-dark);
+  font-family: 'Gentium Book', serif;
+  margin-bottom: 5px;
+}
+
+.witch-iron.chat-card.rout-result-card .card-header {
+  background: var(--color-accent);
+  color: #f5e8d2;
+  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+}
+
+.witch-iron.chat-card.rout-result-card .card-header h3 {
+  margin: 0;
+  font-size: 1.2em;
+  font-weight: bold;
+}
+
+.witch-iron.chat-card.rout-result-card .card-content {
+  padding: 12px;
+  text-align: center;
+}
+
+.rout-check-dialog .dialog-buttons button {
+  background: var(--color-accent);
+  color: #f5e8d2;
+}
+
+.rout-check-dialog .dialog-buttons button:hover {
+  background: #7b2d26;
+}

--- a/system.json
+++ b/system.json
@@ -17,13 +17,14 @@
   "esmodules": [
     "scripts/witch-iron.js"
   ],
-  "styles": [
-    "styles/witch-iron.css",
-    "styles/combat-card.css",
-    "styles/hit-location.css",
-    "styles/injury-card.css",
-    "styles/condition-card.css"
-  ],
+    "styles": [
+      "styles/witch-iron.css",
+      "styles/combat-card.css",
+      "styles/hit-location.css",
+      "styles/injury-card.css",
+      "styles/condition-card.css",
+      "styles/mob-card.css"
+    ],
   "packs": [
     {
       "name": "witch-iron-actors",

--- a/templates/chat/mob-injury-message.hbs
+++ b/templates/chat/mob-injury-message.hbs
@@ -1,15 +1,28 @@
 <div class="witch-iron chat-card mob-injury-card">
   <header class="card-header">
+    <i class="fas fa-users-slash"></i>
     <h3>Mob Casualties</h3>
   </header>
   <div class="card-content">
-    <div class="mob-info">
-      <strong>{{defender}}</strong> loses <strong>{{killed}}</strong> bodies.
-      {{#if remaining}}
-        <span>{{remaining}} bodies remain.</span>
-      {{else}}
-        <span>The mob has been destroyed.</span>
-      {{/if}}
+    <div class="mob-summary-number">{{killed}}</div>
+    <div class="mob-summary-text">bodies lost</div>
+    <div class="mob-remaining">{{remaining}} remain</div>
+    {{#if scaleChange}}
+      <div class="scale-change">Scale reduced to <strong>{{newScale}}</strong></div>
+    {{/if}}
+    <div class="collapsible-section">
+      <div class="section-header mob-details-toggle">
+        <i class="fas fa-chevron-down"></i>
+        <h4>Damage Details</h4>
+      </div>
+      <div class="section-content mob-details hidden">
+        <div class="detail-grid">
+          <div class="detail-item"><span class="label">Defender:</span><span class="value">{{defender}}</span></div>
+          <div class="detail-item"><span class="label">Damage:</span><span class="value">{{damage}}</span></div>
+          <div class="detail-item"><span class="label">Lost:</span><span class="value">{{killed}}</span></div>
+          <div class="detail-item"><span class="label">Remaining:</span><span class="value">{{remaining}}</span></div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/templates/chat/rout-result.hbs
+++ b/templates/chat/rout-result.hbs
@@ -1,0 +1,12 @@
+<div class="witch-iron chat-card rout-result-card">
+  <header class="card-header">
+    <h3>Rout Check</h3>
+  </header>
+  <div class="card-content">
+    {{#if success}}
+      <p><strong>{{actor}}</strong> holds their ground.</p>
+    {{else}}
+      <p><strong>{{actor}}</strong> routs!</p>
+    {{/if}}
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add CSS for mob casualty and rout result cards
- improve mob-injury chat card with expandable details and scale change notice
- show follow‑up results after rout checks
- style rout-check dialog buttons for better contrast
- load new styles via system.json

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_684086b8b07c832d937a43e231466506