### PR TITLE
Fix ghost tile visibility

### DIFF
--- a/scripts/ghost-tokens.js
+++ b/scripts/ghost-tokens.js
@@ -78,11 +78,13 @@ export async function syncGhostTiles(token, required) {
       width,
       height,
       img: doc.texture?.src || doc.img,
+      overhead: true,
+      occlusion: { mode: 0 },
       flags: { "witch-iron": { ghostParent: token.id, ghostIndex: i } }
     };
 
     if (tile) {
-      updateData.push({ id: tile.id, ...base });
+      updateData.push({ _id: tile.id, ...base });
       tilesByIndex.delete(i);
     } else {
       createData.push(base);


### PR DESCRIPTION
## Summary
- ensure ghost tiles use `overhead` so they appear above regular tokens

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684089901d64832d8c42e1fada18e0fc