### PR TITLE
Add mob formation setting and hide small mob ghosts

### DIFF
--- a/scripts/ghost-tokens.js
+++ b/scripts/ghost-tokens.js
@@ -1,41 +1,114 @@
-export function computeOffsets(count, start = 0) {
-  const grid = canvas.scene.grid.size;
-  const offsets = [];
-  const visited = new Set(["0,0"]);
-  let frontier = [{ x: 0, y: 0 }];
-  let idx = 0;
+export const FORMATION_SHAPES = [
+  "line",
+  "column",
+  "wedge",
+  "echelonLeft",
+  "echelonRight",
+  "square",
+  "diamond",
+  "circle",
+  "triangle",
+  "skirmish"
+];
 
-  while (offsets.length < count) {
-    const next = [];
-    for (const { x, y } of frontier) {
-      const deltas = [
-        { x: 1, y: 0 },
-        { x: -1, y: 0 },
-        { x: 0, y: 1 },
-        { x: 0, y: -1 },
-        { x: 1, y: 1 },
-        { x: 1, y: -1 },
-        { x: -1, y: 1 },
-        { x: -1, y: -1 },
-      ];
-      for (const d of deltas) {
-        const nx = x + d.x;
-        const ny = y + d.y;
-        const key = `${nx},${ny}`;
-        if (visited.has(key)) continue;
-        visited.add(key);
-        next.push({ x: nx, y: ny });
-        if (idx >= start && offsets.length < count) {
-          offsets.push({ x: nx * grid, y: ny * grid });
-        }
-        idx++;
-        if (offsets.length >= count) break;
-      }
-      if (offsets.length >= count) break;
+export function computeOffsets(count, start = 0, formation = "line") {
+  const grid = canvas.scene.grid.size;
+  const needed = count + start;
+  const coords = [];
+  const add = (x, y) => coords.push({ x: x * grid, y: y * grid });
+
+  switch (formation) {
+    case "line": {
+      for (let i = 1; coords.length < needed; i++) add(i, 0);
+      break;
     }
-    frontier = next;
+    case "column": {
+      for (let i = 1; coords.length < needed; i++) add(0, i);
+      break;
+    }
+    case "wedge": {
+      for (let r = 1; coords.length < needed; r++) {
+        for (let i = -r; i <= r && coords.length < needed; i++) add(i, r);
+      }
+      break;
+    }
+    case "echelonLeft": {
+      for (let i = 1; coords.length < needed; i++) add(-i, i);
+      break;
+    }
+    case "echelonRight": {
+      for (let i = 1; coords.length < needed; i++) add(i, i);
+      break;
+    }
+    case "square": {
+      const side = Math.ceil(Math.sqrt(needed));
+      for (let r = 1; r <= side && coords.length < needed; r++) {
+        for (let c = 0; c < side && coords.length < needed; c++) {
+          add(c - Math.floor(side / 2), r);
+        }
+      }
+      break;
+    }
+    case "diamond": {
+      for (let d = 1; coords.length < needed; d++) {
+        for (let i = -d; i <= d && coords.length < needed; i++) {
+          add(i, d);
+          if (coords.length < needed) add(i, -d);
+        }
+      }
+      break;
+    }
+    case "circle": {
+      const radius = Math.ceil(Math.sqrt(needed));
+      for (let i = 0; i < needed; i++) {
+        const ang = (i / needed) * 2 * Math.PI;
+        add(Math.round(radius * Math.cos(ang)), Math.round(radius * Math.sin(ang)));
+      }
+      break;
+    }
+    case "triangle": {
+      for (let r = 1; coords.length < needed; r++) {
+        for (let i = 0; i < r && coords.length < needed; i++) {
+          add(i - Math.floor(r / 2), r);
+        }
+      }
+      break;
+    }
+    default: { // skirmish/random spread
+      const visited = new Set(["0,0"]);
+      let frontier = [{ x: 0, y: 0 }];
+      while (coords.length < needed) {
+        const next = [];
+        for (const { x, y } of frontier) {
+          const deltas = [
+            { x: 1, y: 0 },
+            { x: -1, y: 0 },
+            { x: 0, y: 1 },
+            { x: 0, y: -1 },
+            { x: 1, y: 1 },
+            { x: 1, y: -1 },
+            { x: -1, y: 1 },
+            { x: -1, y: -1 },
+          ].sort(() => Math.random() - 0.5);
+          for (const d of deltas) {
+            const nx = x + d.x;
+            const ny = y + d.y;
+            const key = `${nx},${ny}`;
+            if (visited.has(key)) continue;
+            visited.add(key);
+            next.push({ x: nx, y: ny });
+            add(nx, ny);
+            if (coords.length >= needed) break;
+          }
+          if (coords.length >= needed) break;
+        }
+        frontier = next;
+      }
+      break;
+    }
   }
-  return offsets;
+
+  return coords.slice(start, start + count);
 }
 
 export async function spawnGhostTokens(token) {
@@ -43,6 +116,7 @@ export async function spawnGhostTokens(token) {
   if (!actor?.system?.mob?.isMob?.value) return;
 
   const bodies = actor.system.mob.bodies?.value || 1;
+  if (bodies < 5) return;
   await token.update({
     [`flags.witch-iron.isMobLeader`]: true,
     overlayEffect: "icons/svg/target.svg"
@@ -52,7 +126,8 @@ export async function spawnGhostTokens(token) {
 
 export async function syncGhostTiles(token, required, overrides = {}) {
   const tiles = canvas.scene.tiles.filter(t => t.getFlag("witch-iron", "ghostParent") === token.id);
-  const offsets = computeOffsets(required, 0);
+  const formation = game.settings.get("witch-iron", "mobFormationShape") || "line";
+  const offsets = computeOffsets(required, 0, formation);
 
   const tilesByIndex = new Map();
   for (const tile of tiles) {
@@ -133,8 +208,9 @@ Hooks.on("updateActor", actor => {
   const tokens = canvas.scene.tokens.filter(t => t.actor?.id === actor.id);
   const isMob = actor.system?.mob?.isMob?.value;
   const bodies = actor.system?.mob?.bodies?.value || 1;
+  const show = isMob && bodies >= 5;
   tokens.forEach(t => {
-    if (isMob) {
+    if (show) {
       if (!t.getFlag("witch-iron", "isMobLeader")) {
         spawnGhostTokens(t);
       } else {

--- a/scripts/witch-iron.js
+++ b/scripts/witch-iron.js
@@ -15,6 +15,7 @@ import { initQuarrel, manualQuarrel, quarrelTracker } from "./quarrel.js";
 import { HitLocationSelector } from "./hit-location.js";
 import { InjuryTables } from "./injury-tables.js";
 import { registerCommonHandlebarsHelpers } from "./handlebars-helpers.js";
+import { FORMATION_SHAPES } from "./ghost-tokens.js";
 import "./ghost-tokens.js";
 
 // Define the system configuration object
@@ -95,6 +96,27 @@ Hooks.once("init", function() {
       if (game.user.isGM) {
         const status = value ? "enabled" : "disabled";
         ui.notifications.info(`Witch Iron: Extended roll visibility ${status}`);
+      }
+    }
+  });
+
+  // Setting for mob formation shape
+  const formationChoices = FORMATION_SHAPES.reduce((obj, s) => {
+    const label = s.replace(/([A-Z])/g, " $1").replace(/^./, c => c.toUpperCase());
+    obj[s] = label;
+    return obj;
+  }, {});
+  game.settings.register("witch-iron", "mobFormationShape", {
+    name: "Mob Formation Shape",
+    hint: "Shape used for mob ghost tokens.",
+    scope: "world",
+    config: true,
+    type: String,
+    choices: formationChoices,
+    default: FORMATION_SHAPES[0],
+    onChange: value => {
+      if (game.user.isGM) {
+        ui.notifications.info(`Witch Iron: Mob formation set to ${value}`);
       }
     }
   });


### PR DESCRIPTION
## Summary
- allow customizing ghost token formation shape
- don't spawn ghost tokens if a mob has fewer than five bodies
- register a new world setting `mobFormationShape`

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_68409158ad6c832da27f1f7e99b0daf5