### PR TITLE
Enhance mob casualty and rout UX

### DIFF
--- a/styles/casualty-cards.css
+++ b/styles/casualty-cards.css
@@ -1,0 +1,129 @@
+/* Casualty and Rout Result Card Styles */
+.witch-iron.chat-card.mob-casualty-card,
+.witch-iron.chat-card.rout-result-card {
+  border: 1px solid var(--color-border-light);
+  border-radius: 6px;
+  margin: 0;
+  background: #fff;
+  color: var(--color-text-dark);
+  font-family: 'Gentium Book', serif;
+  overflow: hidden;
+}
+
+.witch-iron.chat-card.mob-casualty-card .card-header,
+.witch-iron.chat-card.rout-result-card .card-header {
+  background: var(--color-accent);
+  color: #f5e8d2;
+  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.witch-iron.chat-card.mob-casualty-card .card-header h3,
+.witch-iron.chat-card.rout-result-card .card-header h3 {
+  margin: 0;
+  font-size: 1.2em;
+  font-weight: bold;
+}
+
+.witch-iron.chat-card.mob-casualty-card .card-content,
+.witch-iron.chat-card.rout-result-card .card-content {
+  padding: 12px;
+}
+
+.mob-casualty-card .casualty-summary {
+  display: flex;
+  justify-content: space-around;
+  margin-bottom: 0.5em;
+  font-size: 1.1em;
+  font-weight: bold;
+}
+.mob-casualty-card .casualty-summary .losses {
+  color: var(--color-accent);
+}
+.mob-casualty-card .casualty-summary .remaining {
+  color: var(--color-success);
+}
+
+.mob-casualty-card .scale-change {
+  text-align: center;
+  color: var(--color-accent);
+  margin-bottom: 0.5em;
+}
+
+.mob-casualty-card .big-numbers {
+  text-align: center;
+  font-size: 1.6em;
+  font-weight: bold;
+  color: var(--color-accent);
+  margin-top: 0.5em;
+}
+
+.mob-casualty-card .collapsible-section {
+  border: 1px solid rgba(123,45,38,0.2);
+  border-radius: 6px;
+  overflow: hidden;
+  margin-top: 0.5em;
+}
+
+.mob-casualty-card .section-header {
+  display: flex;
+  align-items: center;
+  padding: 5px 10px;
+  background: rgba(123,45,38,0.1);
+  cursor: pointer;
+}
+
+.mob-casualty-card .section-header i {
+  margin-right: 8px;
+  transition: transform 0.3s;
+}
+
+.mob-casualty-card .section-header.open i {
+  transform: rotate(180deg);
+}
+
+.mob-casualty-card .section-content {
+  padding: 10px;
+  background: rgba(0,0,0,0.02);
+}
+
+.mob-casualty-card .section-content.hidden { display:none; }
+
+.mob-casualty-card .detail-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.25em 1em;
+}
+
+.mob-casualty-card .detail-item {
+  display: flex;
+  justify-content: space-between;
+  padding: 2px 0;
+}
+.mob-casualty-card .detail-item .label {
+  font-weight: bold;
+  color: var(--color-text-muted);
+}
+.mob-casualty-card .detail-item .value {
+  color: var(--color-text-dark);
+}
+
+/* Rout check dialog buttons with better contrast */
+.rout-check-dialog .dialog-buttons button {
+  background: var(--color-accent);
+  color: #f5e8d2;
+  border: 1px solid var(--color-border-dark);
+}
+
+.rout-check-dialog .dialog-buttons button:hover {
+  background: #601f1a;
+}
+
+/* Default dialog button contrast */
+.dialog .dialog-buttons button.default {
+  background: rgba(50, 50, 50, 0.8);
+  color: var(--color-highlight);
+}

--- a/system.json
+++ b/system.json
@@ -22,7 +22,8 @@
     "styles/combat-card.css",
     "styles/hit-location.css",
     "styles/injury-card.css",
-    "styles/condition-card.css"
+    "styles/condition-card.css",
+    "styles/casualty-cards.css"
   ],
   "packs": [
     {

--- a/templates/chat/mob-injury-message.hbs
+++ b/templates/chat/mob-injury-message.hbs
@@ -1,15 +1,29 @@
-<div class="witch-iron chat-card mob-injury-card">
+<div class="witch-iron chat-card mob-casualty-card">
   <header class="card-header">
+    <i class="fas fa-skull-crossbones"></i>
     <h3>Mob Casualties</h3>
   </header>
   <div class="card-content">
-    <div class="mob-info">
-      <strong>{{defender}}</strong> loses <strong>{{killed}}</strong> bodies.
-      {{#if remaining}}
-        <span>{{remaining}} bodies remain.</span>
-      {{else}}
-        <span>The mob has been destroyed.</span>
-      {{/if}}
+    <div class="casualty-summary">
+      <span class="losses">Losses: {{killed}}</span>
+      <span class="remaining">Remaining: {{remaining}}</span>
+    </div>
+    {{#if scaleChange}}
+    <div class="scale-change">Scale reduced to {{newScale}}</div>
+    {{/if}}
+    <div class="big-numbers">{{killed}} / {{remaining}}</div>
+    <div class="collapsible-section">
+      <div class="section-header casualty-toggle">
+        <i class="fas fa-chevron-down"></i>
+        <h4>Damage Details</h4>
+      </div>
+      <div class="section-content casualty-details hidden">
+        <div class="detail-grid">
+          <div class="detail-item"><span class="label">Damage:</span> <span class="value">{{damage}}</span></div>
+          <div class="detail-item"><span class="label">Bodies Lost:</span> <span class="value">{{killed}}</span></div>
+          <div class="detail-item"><span class="label">Bodies Remaining:</span> <span class="value">{{remaining}}</span></div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/templates/chat/rout-result.hbs
+++ b/templates/chat/rout-result.hbs
@@ -1,0 +1,9 @@
+<div class="witch-iron chat-card rout-result-card">
+  <header class="card-header">
+    <i class="fas fa-flag"></i>
+    <h3>Rout Result</h3>
+  </header>
+  <div class="card-content">
+    <p class="rout-summary"><strong>{{mob}}</strong> {{#if success}}holds its ground{{else}}routs!{{/if}}</p>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- style casualty cards, rout result cards, and rout dialogs
- show more detail in mob casualty chat cards
- add rout result chat card template
- report scale losses and rout outcomes in scripts
- improve casualty card styling and button contrast

## Testing
- `node -c scripts/hit-location.js`


------
https://chatgpt.com/codex/tasks/task_e_68408a355434832da929596a18326269