### PR TITLE
Add mob formation setting and hide small mob ghosts

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -79,7 +79,8 @@
       "flaw": "Flaw",
       "specialQualities": "Special Qualities",
       "isMob": "Is Mob",
-      "bodies": "Bodies"
+      "bodies": "Bodies",
+      "formation": "Formation"
     },
     "sizes": {
       "tiny": "Tiny",

--- a/scripts/actor.js
+++ b/scripts/actor.js
@@ -306,7 +306,10 @@ export class WitchIronActor extends Actor {
     }
     
     if (!systemData.derived) systemData.derived = {};
-    if (!systemData.mob) systemData.mob = { isMob: { value: false }, bodies: { value: 0 } };
+    if (!systemData.mob) systemData.mob = { isMob: { value: false }, bodies: { value: 0 }, formation: { value: "skirmish" } };
+    else {
+      if (!systemData.mob.formation) systemData.mob.formation = { value: "skirmish" };
+    }
     if (!systemData.traits) systemData.traits = { specialQualities: [], flaw: { value: "" } };
     
     // Monster ability score based on Hit Dice from V3 table

--- a/scripts/ghost-tokens.js
+++ b/scripts/ghost-tokens.js
@@ -1,41 +1,136 @@
-export function computeOffsets(count, start = 0) {
-  const grid = canvas.scene.grid.size;
-  const offsets = [];
-  const visited = new Set(["0,0"]);
-  let frontier = [{ x: 0, y: 0 }];
-  let idx = 0;
+export const FORMATION_SHAPES = [
+  "skirmish",
+  "lineSingle",
+  "lineDouble",
+  "lineTriple",
+  "column",
+  "wedge",
+  "echelonLeft",
+  "echelonRight",
+  "square",
+  "diamond",
+  "circle",
+  "triangle"
+];
 
-  while (offsets.length < count) {
-    const next = [];
-    for (const { x, y } of frontier) {
-      const deltas = [
-        { x: 1, y: 0 },
-        { x: -1, y: 0 },
-        { x: 0, y: 1 },
-        { x: 0, y: -1 },
-        { x: 1, y: 1 },
-        { x: 1, y: -1 },
-        { x: -1, y: 1 },
-        { x: -1, y: -1 },
-      ];
-      for (const d of deltas) {
-        const nx = x + d.x;
-        const ny = y + d.y;
-        const key = `${nx},${ny}`;
-        if (visited.has(key)) continue;
-        visited.add(key);
-        next.push({ x: nx, y: ny });
-        if (idx >= start && offsets.length < count) {
-          offsets.push({ x: nx * grid, y: ny * grid });
-        }
-        idx++;
-        if (offsets.length >= count) break;
-      }
-      if (offsets.length >= count) break;
+export function computeOffsets(count, start = 0, formation = "skirmish") {
+  const grid = canvas.scene.grid.size;
+  const needed = count + start;
+  const coords = [];
+  const add = (x, y) => coords.push({ x: x * grid, y: y * grid });
+
+  switch (formation) {
+    case "lineSingle": {
+      for (let i = 1; coords.length < needed; i++) add(i, 0);
+      break;
     }
-    frontier = next;
+    case "lineDouble": {
+      for (let i = 1; coords.length < needed; i++) {
+        add(i, 0);
+        if (coords.length < needed) add(i, 1);
+      }
+      break;
+    }
+    case "lineTriple": {
+      for (let i = 1; coords.length < needed; i++) {
+        add(i, -1);
+        if (coords.length < needed) add(i, 0);
+        if (coords.length < needed) add(i, 1);
+      }
+      break;
+    }
+    case "column": {
+      for (let i = 1; coords.length < needed; i++) add(0, i);
+      break;
+    }
+    case "wedge": {
+      for (let r = 1; coords.length < needed; r++) {
+        for (let i = -r; i <= r && coords.length < needed; i++) add(i, r);
+      }
+      break;
+    }
+    case "echelonLeft": {
+      for (let i = 1; coords.length < needed; i++) add(-i, i);
+      break;
+    }
+    case "echelonRight": {
+      for (let i = 1; coords.length < needed; i++) add(i, i);
+      break;
+    }
+    case "square": {
+      const side = Math.ceil(Math.sqrt(needed));
+      for (let r = 1; r <= side && coords.length < needed; r++) {
+        for (let c = 0; c < side && coords.length < needed; c++) {
+          add(c - Math.floor(side / 2), r);
+        }
+      }
+      break;
+    }
+    case "diamond": {
+      for (let r = 1; coords.length < needed; r++) {
+        for (let x = -r; x <= r && coords.length < needed; x++) {
+          const y = r - Math.abs(x);
+          if (y > 0) {
+            add(x, y);
+            if (coords.length < needed) add(x, -y);
+          } else {
+            add(x, 0);
+          }
+        }
+      }
+      break;
+    }
+    case "circle": {
+      const radius = Math.ceil(Math.sqrt(needed));
+      for (let i = 0; i < needed; i++) {
+        const ang = (i / needed) * 2 * Math.PI;
+        add(Math.round(radius * Math.cos(ang)), Math.round(radius * Math.sin(ang)));
+      }
+      break;
+    }
+    case "triangle": {
+      for (let r = 1; coords.length < needed; r++) {
+        for (let i = 0; i < r && coords.length < needed; i++) {
+          add(i - Math.floor(r / 2), r);
+        }
+      }
+      break;
+    }
+    default: { // skirmish/random spread
+      const visited = new Set(["0,0"]);
+      let frontier = [{ x: 0, y: 0 }];
+      while (coords.length < needed) {
+        const next = [];
+        for (const { x, y } of frontier) {
+          const deltas = [
+            { x: 1, y: 0 },
+            { x: -1, y: 0 },
+            { x: 0, y: 1 },
+            { x: 0, y: -1 },
+            { x: 1, y: 1 },
+            { x: 1, y: -1 },
+            { x: -1, y: 1 },
+            { x: -1, y: -1 },
+          ].sort(() => Math.random() - 0.5);
+          for (const d of deltas) {
+            const nx = x + d.x;
+            const ny = y + d.y;
+            const key = `${nx},${ny}`;
+            if (visited.has(key)) continue;
+            visited.add(key);
+            next.push({ x: nx, y: ny });
+            add(nx, ny);
+            if (coords.length >= needed) break;
+          }
+          if (coords.length >= needed) break;
+        }
+        frontier = next;
+      }
+      break;
+    }
   }
-  return offsets;
+
+  return coords.slice(start, start + count);
 }
 
 export async function spawnGhostTokens(token) {
@@ -43,8 +138,9 @@ export async function spawnGhostTokens(token) {
   if (!actor?.system?.mob?.isMob?.value) return;
 
   const bodies = actor.system.mob.bodies?.value || 1;
+  if (bodies < 5) return;
   await token.update({
-    [`flags.witch-iron.isMobLeader`]: true,
+    ["flags.witch-iron.isMobLeader"]: true,
     overlayEffect: "icons/svg/target.svg"
   });
   await syncGhostTiles(token, bodies - 1);
@@ -52,7 +148,8 @@ export async function spawnGhostTokens(token) {
 
 export async function syncGhostTiles(token, required, overrides = {}) {
   const tiles = canvas.scene.tiles.filter(t => t.getFlag("witch-iron", "ghostParent") === token.id);
-  const offsets = computeOffsets(required, 0);
+  const actorFormation = token.actor?.system?.mob?.formation?.value || "skirmish";
+  const offsets = computeOffsets(required, 0, actorFormation);
 
   const tilesByIndex = new Map();
   for (const tile of tiles) {
@@ -133,8 +230,9 @@ Hooks.on("updateActor", actor => {
   const tokens = canvas.scene.tokens.filter(t => t.actor?.id === actor.id);
   const isMob = actor.system?.mob?.isMob?.value;
   const bodies = actor.system?.mob?.bodies?.value || 1;
+  const show = isMob && bodies >= 5;
   tokens.forEach(t => {
-    if (isMob) {
+    if (show) {
       if (!t.getFlag("witch-iron", "isMobLeader")) {
         spawnGhostTokens(t);
       } else {

--- a/scripts/monster-sheet.js
+++ b/scripts/monster-sheet.js
@@ -5,6 +5,7 @@
 import { manualQuarrel } from "./quarrel.js";
 import { createItem } from "./utils.js";
 import { openModifierDialog } from "./modifier-dialog.js";
+import { FORMATION_SHAPES } from "./ghost-tokens.js";
 
 /**
  * Monster sheet class for the Witch Iron system
@@ -168,6 +169,12 @@ export class WitchIronMonsterSheet extends ActorSheet {
     // Prepare sizes for select
     const sizesConfig = witchIronConfig.sizes || {};
     context.sizes = Object.entries(sizesConfig).map(([key, label]) => ({ key, label }));
+
+    // Formation shape options
+    context.formationShapes = FORMATION_SHAPES.map(s => ({
+      key: s,
+      label: s.replace(/([A-Z])/g, " $1").replace(/^./, c => c.toUpperCase())
+    }));
 
     // Add actor's items to the context
     context.items = actorData.items;

--- a/scripts/witch-iron.js
+++ b/scripts/witch-iron.js
@@ -99,6 +99,7 @@ Hooks.once("init", function() {
     }
   });
 
+
   // Register hidden world setting for injury sheet default values
   game.settings.register("witch-iron", "injurySheetDefaults", {
     name: "Injury Sheet Default Values",

--- a/template.json
+++ b/template.json
@@ -195,6 +195,9 @@
         },
         "bodies": {
           "value": 0
+        },
+        "formation": {
+          "value": "skirmish"
         }
       },
       "traits": {

--- a/templates/actors/monster-sheet.hbs
+++ b/templates/actors/monster-sheet.hbs
@@ -205,6 +205,12 @@
                   <input type="number" name="system.mob.bodies.value" value="{{system.mob.bodies.value}}">
                 </div>
                 <div class="form-group">
+                  <label>Formation</label>
+                  <select name="system.mob.formation.value">
+                    {{selectOptions formationShapes selected=system.mob.formation.value localize=false}}
+                  </select>
+                </div>
+                <div class="form-group">
                   <label>Mob Scale</label>
                   <span>{{system.derived.mobScale}}</span>
                 </div>


### PR DESCRIPTION
## Summary
- allow customizing ghost token formation per mob
- default formation is skirmish
- add single/double/triple line formations and fix diamond pattern
- remove global mobFormationShape setting
- show formation select in monster mob section

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_68409158ad6c832da27f1f7e99b0daf5