### PR TITLE
Improve casualty card visuals

### DIFF
--- a/styles/casualty-cards.css
+++ b/styles/casualty-cards.css
@@ -41,6 +41,14 @@
   font-weight: bold;
 }
 
+.mob-casualty-card .casualty-summary .losses {
+  color: var(--color-accent);
+}
+
+.mob-casualty-card .casualty-summary .remaining {
+  color: var(--color-success);
+}
+
 .mob-casualty-card .scale-change {
   text-align: center;
   color: var(--color-accent);
@@ -51,6 +59,7 @@
   text-align: center;
   font-size: 1.4em;
   margin-top: 0.5em;
+  color: var(--color-accent);
 }
 
 .mob-casualty-card .collapsible-section {
@@ -94,6 +103,14 @@
   display: flex;
   justify-content: space-between;
   padding: 2px 0;
+}
+.mob-casualty-card .detail-item .label {
+  font-weight: bold;
+  color: var(--color-text-muted);
+}
+
+.mob-casualty-card .detail-item .value {
+  color: var(--color-text-dark);
 }
 
 /* Rout check dialog buttons with better contrast */

--- a/styles/witch-iron.css
+++ b/styles/witch-iron.css
@@ -3708,3 +3708,9 @@ button.roll-skill:hover {
   align-items: center;
   justify-content: space-between;
 }
+
+/* Darker default dialog buttons for better contrast */
+.dialog .dialog-buttons button.default {
+  background: rgba(50, 50, 50, 0.8);
+  color: var(--color-surface-light);
+}

--- a/templates/chat/mob-injury-message.hbs
+++ b/templates/chat/mob-injury-message.hbs
@@ -1,5 +1,6 @@
 <div class="witch-iron chat-card mob-casualty-card">
   <header class="card-header">
+    <i class="fas fa-skull-crossbones"></i>
     <h3>Mob Casualties</h3>
   </header>
   <div class="card-content">

--- a/templates/chat/rout-result.hbs
+++ b/templates/chat/rout-result.hbs
@@ -1,5 +1,6 @@
 <div class="witch-iron chat-card rout-result-card">
   <header class="card-header">
+    <i class="fas fa-flag"></i>
     <h3>Rout Result</h3>
   </header>
   <div class="card-content">


### PR DESCRIPTION
## Summary
- tweak leader check dialog button background to darker gray
- add skull icon to casualty cards
- add flag icon to rout result cards
- style losses and remaining bodies in casualty cards
- reuse injury card label styling in casualty cards

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6840978a4a80832d904ff2b7351e7d2c