### PR TITLE
Add mob formation options and diamond fix

### DIFF
--- a/scripts/actor.js
+++ b/scripts/actor.js
@@ -306,7 +306,8 @@ export class WitchIronActor extends Actor {
     }
     
     if (!systemData.derived) systemData.derived = {};
-    if (!systemData.mob) systemData.mob = { isMob: { value: false }, bodies: { value: 0 } };
+    if (!systemData.mob) systemData.mob = { isMob: { value: false }, bodies: { value: 0 }, formation: { value: "skirmish" } };
+    if (!systemData.mob.formation) systemData.mob.formation = { value: "skirmish" };
     if (!systemData.traits) systemData.traits = { specialQualities: [], flaw: { value: "" } };
     
     // Monster ability score based on Hit Dice from V3 table

--- a/scripts/ghost-tokens.js
+++ b/scripts/ghost-tokens.js
@@ -1,9 +1,17 @@
 export const FORMATION_SHAPES = [
   "line",
+  "doubleLine",
+  "tripleLine",
   "column",
+  "doubleColumn",
+  "tripleColumn",
   "wedge",
   "echelonLeft",
+  "doubleEchelonLeft",
+  "tripleEchelonLeft",
   "echelonRight",
+  "doubleEchelonRight",
+  "tripleEchelonRight",
   "square",
   "diamond",
   "circle",
@@ -11,7 +19,7 @@ export const FORMATION_SHAPES = [
   "skirmish"
 ];
 
-export function computeOffsets(count, start = 0, formation = "line") {
+export function computeOffsets(count, start = 0, formation = "skirmish") {
   const grid = canvas.scene.grid.size;
   const needed = count + start;
   const coords = [];
@@ -22,8 +30,38 @@ export function computeOffsets(count, start = 0, formation = "line") {
       for (let i = 1; coords.length < needed; i++) add(i, 0);
       break;
     }
+    case "doubleLine": {
+      for (let i = 1; coords.length < needed; i++) {
+        add(i, 0);
+        if (coords.length < needed) add(i, 1);
+      }
+      break;
+    }
+    case "tripleLine": {
+      for (let i = 1; coords.length < needed; i++) {
+        add(i, 0);
+        if (coords.length < needed) add(i, 1);
+        if (coords.length < needed) add(i, -1);
+      }
+      break;
+    }
     case "column": {
       for (let i = 1; coords.length < needed; i++) add(0, i);
+      break;
+    }
+    case "doubleColumn": {
+      for (let i = 1; coords.length < needed; i++) {
+        add(0, i);
+        if (coords.length < needed) add(1, i);
+      }
+      break;
+    }
+    case "tripleColumn": {
+      for (let i = 1; coords.length < needed; i++) {
+        add(0, i);
+        if (coords.length < needed) add(1, i);
+        if (coords.length < needed) add(-1, i);
+      }
       break;
     }
     case "wedge": {
@@ -36,8 +74,38 @@ export function computeOffsets(count, start = 0, formation = "line") {
       for (let i = 1; coords.length < needed; i++) add(-i, i);
       break;
     }
+    case "doubleEchelonLeft": {
+      for (let i = 1; coords.length < needed; i++) {
+        add(-i, i);
+        if (coords.length < needed) add(-i + 1, i + 1);
+      }
+      break;
+    }
+    case "tripleEchelonLeft": {
+      for (let i = 1; coords.length < needed; i++) {
+        add(-i, i);
+        if (coords.length < needed) add(-i + 1, i + 1);
+        if (coords.length < needed) add(-i - 1, i - 1);
+      }
+      break;
+    }
     case "echelonRight": {
       for (let i = 1; coords.length < needed; i++) add(i, i);
+      break;
+    }
+    case "doubleEchelonRight": {
+      for (let i = 1; coords.length < needed; i++) {
+        add(i, i);
+        if (coords.length < needed) add(i + 1, i - 1);
+      }
+      break;
+    }
+    case "tripleEchelonRight": {
+      for (let i = 1; coords.length < needed; i++) {
+        add(i, i);
+        if (coords.length < needed) add(i + 1, i - 1);
+        if (coords.length < needed) add(i - 1, i + 1);
+      }
       break;
     }
     case "square": {
@@ -51,9 +119,14 @@ export function computeOffsets(count, start = 0, formation = "line") {
     }
     case "diamond": {
       for (let d = 1; coords.length < needed; d++) {
-        for (let i = -d; i <= d && coords.length < needed; i++) {
-          add(i, d);
-          if (coords.length < needed) add(i, -d);
+        for (let x = -d; x <= d && coords.length < needed; x++) {
+          const y = d - Math.abs(x);
+          if (y > 0) {
+            add(x, y);
+            if (coords.length < needed) add(x, -y);
+          } else {
+            add(x, 0);
+          }
         }
       }
       break;
@@ -126,7 +199,7 @@ export async function spawnGhostTokens(token) {
 
 export async function syncGhostTiles(token, required, overrides = {}) {
   const tiles = canvas.scene.tiles.filter(t => t.getFlag("witch-iron", "ghostParent") === token.id);
-  const formation = game.settings.get("witch-iron", "mobFormationShape") || "line";
+  const formation = token.actor?.system?.mob?.formation?.value || "skirmish";
   const offsets = computeOffsets(required, 0, formation);
 
   const tilesByIndex = new Map();

--- a/scripts/monster-sheet.js
+++ b/scripts/monster-sheet.js
@@ -5,6 +5,7 @@
 import { manualQuarrel } from "./quarrel.js";
 import { createItem } from "./utils.js";
 import { openModifierDialog } from "./modifier-dialog.js";
+import { FORMATION_SHAPES } from "./ghost-tokens.js";
 
 /**
  * Monster sheet class for the Witch Iron system
@@ -168,6 +169,13 @@ export class WitchIronMonsterSheet extends ActorSheet {
     // Prepare sizes for select
     const sizesConfig = witchIronConfig.sizes || {};
     context.sizes = Object.entries(sizesConfig).map(([key, label]) => ({ key, label }));
+
+    // Prepare formation options for select
+    context.formations = FORMATION_SHAPES.reduce((obj, s) => {
+      const label = s.replace(/([A-Z])/g, " $1").replace(/^./, c => c.toUpperCase());
+      obj[s] = label;
+      return obj;
+    }, {});
 
     // Add actor's items to the context
     context.items = actorData.items;

--- a/scripts/witch-iron.js
+++ b/scripts/witch-iron.js
@@ -113,7 +113,7 @@ Hooks.once("init", function() {
     config: true,
     type: String,
     choices: formationChoices,
-    default: FORMATION_SHAPES[0],
+    default: "skirmish",
     onChange: value => {
       if (game.user.isGM) {
         ui.notifications.info(`Witch Iron: Mob formation set to ${value}`);

--- a/template.json
+++ b/template.json
@@ -195,6 +195,9 @@
         },
         "bodies": {
           "value": 0
+        },
+        "formation": {
+          "value": "skirmish"
         }
       },
       "traits": {

--- a/templates/actors/monster-sheet.hbs
+++ b/templates/actors/monster-sheet.hbs
@@ -212,6 +212,12 @@
                   <label>Mob Attacks</label>
                   <span>{{system.derived.mobAttacks}}</span>
                 </div>
+                <div class="form-group">
+                  <label>Formation</label>
+                  <select name="system.mob.formation.value">
+                    {{selectOptions formations selected=system.mob.formation.value localize=false}}
+                  </select>
+                </div>
               {{/if}}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add new `formation` field to actor mob data with default `skirmish`
- allow mobs to choose formations from the monster sheet
- expand formation shapes to include double and triple lines
- default formation for ghost tokens is now `skirmish`
- fix diamond formation logic to create proper diamond
- add double and triple width for echelon and column formations

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684098b58210832d8aa71f5e4487c118