### PR TITLE
Improve mob casualty layout

### DIFF
--- a/scripts/hit-location.js
+++ b/scripts/hit-location.js
@@ -548,6 +548,11 @@ export class HitLocationSelector {
                     killed: bodiesKilled,
                     remaining: remainingBodies,
                     damage: netDamage,
+                    damageText: damageText,
+                    soakText: soakText,
+                    netHits: netHits,
+                    netDamage: netDamage,
+                    location: combatData.location,
                     scaleChange: scaleChange,
                     newScale: newScale,
                     lossPercent: lossPercent

--- a/styles/casualty-cards.css
+++ b/styles/casualty-cards.css
@@ -6,10 +6,14 @@
 
 /* <details> styling for casualty sections */
 .mob-casualty-card details {
-  margin-top: 0.5em;
-  border: 1px solid rgba(123,45,38,0.2);
-  border-radius: 6px;
-  padding: 0.5em;
+  margin: 0.5em 0;
+  padding: 0.5em 0.5em;
+  border-top: 1px solid rgba(123,45,38,0.2);
+  border-bottom: 1px solid rgba(123,45,38,0.2);
+}
+
+.mob-casualty-card details + details {
+  border-top: none;
 }
 
 .mob-casualty-card summary {

--- a/templates/chat/mob-injury-message.hbs
+++ b/templates/chat/mob-injury-message.hbs
@@ -1,27 +1,30 @@
-<section class="witch-iron chat-card wi-card mob-casualty-card">
-  <header class="card-header">
+<div class="witch-iron chat-card wi-card mob-casualty-card">
+  <div class="card-header">
     <i class="fas fa-skull-crossbones"></i>
     <h3>Mob Casualties</h3>
-  </header>
+  </div>
+  <div class="card-content">
+    <details class="cas-detail" open>
+      <summary>Casualty Summary</summary>
+      <div class="grid-two">
+        <span class="label">Losses:</span><span class="value">{{killed}}</span>
+        <span class="label">Remaining:</span><span class="value">{{remaining}}</span>
+        <span class="label">Scale:</span><span class="value">{{newScale}} {{#if scaleChange}}(↓){{/if}}</span>
+      </div>
+      <div class="progress">
+        <div style="width:{{lossPercent}}%"></div>
+      </div>
+    </details>
 
-  <details class="cas-detail" open>
-    <summary>Casualty Summary</summary>
-    <div class="grid-two">
-      <span class="label">Losses:</span><span class="value">{{killed}}</span>
-      <span class="label">Remaining:</span><span class="value">{{remaining}}</span>
-      <span class="label">Scale:</span><span class="value">{{newScale}} {{#if scaleChange}}(↓){{/if}}</span>
-    </div>
-    <div class="progress">
-      <div style="width:{{lossPercent}}%"></div>
-    </div>
-  </details>
-
-  <details class="cas-detail">
-    <summary>Damage Details</summary>
-    <div class="grid-two fade">
-      <span class="label">Damage:</span><span class="value">{{damage}}</span>
-      <span class="label">Bodies Lost:</span><span class="value">{{killed}}</span>
-      <span class="label">Bodies Remaining:</span><span class="value">{{remaining}}</span>
-    </div>
-  </details>
-</section>
+    <details class="cas-detail">
+      <summary>Combat Details</summary>
+      <div class="grid-two fade">
+        <span class="label">Damage:</span><span class="value">{{damageText}}</span>
+        <span class="label">Soak:</span><span class="value">{{soakText}}</span>
+        <span class="label">Net Hits:</span><span class="value">{{netHits}}</span>
+        <span class="label">Net Dmg:</span><span class="value">{{netDamage}}</span>
+        <div class="wide"><span class="label">Hit the...</span><span class="value">{{location}}</span></div>
+      </div>
+    </details>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- modernize mob casualty card template
- supply combat data to the mob casualty chat card
- refine casualty card styling

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6840b48cc408832dad2fbdba38e2e9d4