### PR TITLE
Fix critical hit and fumble calculations

### DIFF
--- a/scripts/actor.js
+++ b/scripts/actor.js
@@ -844,8 +844,8 @@ export class WitchIronActor extends Actor {
     });
     
     // Apply critical effects
-    if (isCriticalSuccess) hits = Math.max(hits + 1, 1);  // At least 1 hit on crit success
-    if (isFumble) hits = Math.min(hits - 1, -1);  // At most -1 hit on fumble
+    if (isCriticalSuccess) hits = Math.max(hits + 1, 6);  // At least 6 hits on crit success
+    if (isFumble) hits = Math.min(hits - 1, -6);  // At most -6 hits on fumble
     
     // Get roll mode and extended visibility setting
     const rollMode = game.settings.get("core", "rollMode");

--- a/scripts/hit-location.js
+++ b/scripts/hit-location.js
@@ -59,8 +59,8 @@ async function performRoutRoll(actor, label, targetValue) {
     const isCriticalSuccess = rollTotal <= 5 || (isSuccess && rollTotal % 11 === 0);
     const isFumble = rollTotal >= 96 || (!isSuccess && rollTotal % 11 === 0);
     let hits = Math.floor(targetValue/10) - Math.floor(rollTotal/10);
-    if (isCriticalSuccess) hits = Math.max(hits + 1, 1);
-    if (isFumble) hits = Math.min(hits - 1, -1);
+    if (isCriticalSuccess) hits = Math.max(hits + 1, 6);
+    if (isFumble) hits = Math.min(hits - 1, -6);
 
     const content = await renderTemplate("systems/witch-iron/templates/chat/roll-card.hbs", {
         actor,


### PR DESCRIPTION
## Summary
- ensure critical successes add at least 6 Hits
- ensure fumbles remove up to 6 Hits

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6840b553e34c832db1a6f5ad46ea8c0f