### PR TITLE
Fix critical hit and fumble calculations

### DIFF
--- a/scripts/actor.js
+++ b/scripts/actor.js
@@ -828,7 +828,8 @@ export class WitchIronActor extends Actor {
     
     // Calculate hits (no need to recalculate if additionalHits is provided for monsters)
     const baseHits = Math.floor(targetValue/10) - Math.floor(rollTotal/10);
-    let hits = baseHits + additionalHits;
+    let hits = baseHits;
+    if (isSuccess) hits += additionalHits;
     
     // Debug log for calculations
      console.log("Roll Results:", {
@@ -844,8 +845,8 @@ export class WitchIronActor extends Actor {
     });
     
     // Apply critical effects
-    if (isCriticalSuccess) hits = Math.max(hits + 1, 1);  // At least 1 hit on crit success
-    if (isFumble) hits = Math.min(hits - 1, -1);  // At most -1 hit on fumble
+    if (isCriticalSuccess) hits = Math.max(hits + 1, 6);  // At least 6 hits on crit success
+    if (isFumble) hits = Math.min(hits - 1, -6);  // At most -6 hits on fumble
     
     // Get roll mode and extended visibility setting
     const rollMode = game.settings.get("core", "rollMode");

--- a/scripts/hit-location.js
+++ b/scripts/hit-location.js
@@ -59,8 +59,8 @@ async function performRoutRoll(actor, label, targetValue) {
     const isCriticalSuccess = rollTotal <= 5 || (isSuccess && rollTotal % 11 === 0);
     const isFumble = rollTotal >= 96 || (!isSuccess && rollTotal % 11 === 0);
     let hits = Math.floor(targetValue/10) - Math.floor(rollTotal/10);
-    if (isCriticalSuccess) hits = Math.max(hits + 1, 1);
-    if (isFumble) hits = Math.min(hits - 1, -1);
+    if (isCriticalSuccess) hits = Math.max(hits + 1, 6);
+    if (isFumble) hits = Math.min(hits - 1, -6);
 
     const content = await renderTemplate("systems/witch-iron/templates/chat/roll-card.hbs", {
         actor,

--- a/scripts/monster-sheet.js
+++ b/scripts/monster-sheet.js
@@ -483,7 +483,7 @@ export class WitchIronMonsterSheet extends ActorSheet {
       this.actor.rollMonsterCheck({
         label: "Specialized Check",
         ...opts,
-        additionalHits: defaultHits + (opts.additionalHits || 0)
+        additionalHits: opts.additionalHits
       });
     }
   }
@@ -735,12 +735,11 @@ export class WitchIronMonsterSheet extends ActorSheet {
       defaultHits
     });
     if (opts) {
-      const additionalHits = defaultHits + (opts.additionalHits || 0);
       this.actor.rollMonsterCheck({
         label: "Melee Attack",
         ...opts,
         isCombatCheck: true,
-        additionalHits
+        additionalHits: opts.additionalHits
       });
     }
   }


### PR DESCRIPTION
## Summary
- ensure critical successes add at least 6 Hits
- ensure fumbles remove up to 6 Hits
- only apply +Hits bonuses on successful rolls
- avoid double-counting +Hits from monster sheets

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6840b553e34c832db1a6f5ad46ea8c0f