### PR TITLE
Add fatigue and control conditions

### DIFF
--- a/scripts/actor.js
+++ b/scripts/actor.js
@@ -517,12 +517,28 @@ export class WitchIronActor extends Actor {
       "stress",
       "blind",
       "deaf",
-      "pain"
+      "pain",
+      "fatigue",
+      "entangle",
+      "helpless",
+      "stun",
+      "prone"
     ];
     if (!systemData.conditions) systemData.conditions = {};
     for (const key of condNames) {
       if (!systemData.conditions[key] || typeof systemData.conditions[key]?.value !== 'number') {
         systemData.conditions[key] = { value: 0 };
+      }
+    }
+
+    // Initialize trauma as an object of locations so multiple traumas can be tracked
+    if (!systemData.conditions.trauma || typeof systemData.conditions.trauma !== 'object') {
+      systemData.conditions.trauma = {};
+    }
+    const traumaLocations = ["head", "torso", "leftArm", "rightArm", "leftLeg", "rightLeg"];
+    for (const loc of traumaLocations) {
+      if (!systemData.conditions.trauma[loc] || typeof systemData.conditions.trauma[loc].value !== 'number') {
+        systemData.conditions.trauma[loc] = { value: 0 };
       }
     }
     


### PR DESCRIPTION
## Summary
- extend monster conditions with fatigue, entangle, helpless, stun, prone and trauma per limb
- show trauma per-location and new conditions on monster sheet
- display explanations for fatigue, entangle, helpless, stun, prone and trauma when clicked
- clarify modifier rows with percentage labels and move target-prone bonus into condition section

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840b5118ff8832d9d6e5408d6ee1640