### PR TITLE
Update Quarrel data when rolls change

### DIFF
--- a/templates/chat/roll-card.hbs
+++ b/templates/chat/roll-card.hbs
@@ -1,4 +1,4 @@
-<div class="witch-iron chat-card witch-iron-roll" data-hits="{{hits}}" data-actor="{{actor.name}}" {{#if isCombatCheck}}data-combat-check="true"{{/if}} data-actor-id="{{actorId}}" data-roll="{{roll.total}}" data-target="{{targetValue}}" data-additional-hits="{{additionalHits}}" data-label="{{label}}" data-specialization="{{specialization}}" data-situational-mod="{{situationalMod}}">
+<div class="witch-iron chat-card witch-iron-roll" data-hits="{{hits}}" data-actor="{{actor.name}}" {{#if isCombatCheck}}data-combat-check="true"{{/if}} data-actor-id="{{actorId}}" data-roll="{{roll.total}}" data-target="{{targetValue}}" data-additional-hits="{{additionalHits}}" data-label="{{label}}" data-specialization="{{specialization}}" data-situational-mod="{{situationalMod}}" data-luck-spent="{{luckSpent}}">
   <header class="card-header">
     <img src="{{actor.img}}" title="{{actor.name}}" width="36" height="36"/>
     <h3>


### PR DESCRIPTION
## Summary
- include `luckSpent` info on all roll cards
- track if luck was used in ability, skill and monster rolls
- update quarrel results when rolls change and broadcast via socket
- listen for quarrel updates to refresh chat cards

## Testing
- `node --check scripts/quarrel.js`
- `node --check scripts/actor.js`


------
https://chatgpt.com/codex/tasks/task_e_6840ba7d878c832d9959b429fb127d21