### PR TITLE
Update Quarrel roll modifications

### DIFF
--- a/templates/chat/roll-card.hbs
+++ b/templates/chat/roll-card.hbs
@@ -1,4 +1,4 @@
-<div class="witch-iron chat-card witch-iron-roll" data-hits="{{hits}}" data-actor="{{actor.name}}" {{#if isCombatCheck}}data-combat-check="true"{{/if}} data-actor-id="{{actorId}}" data-roll="{{roll.total}}" data-target="{{targetValue}}" data-additional-hits="{{additionalHits}}" data-label="{{label}}" data-specialization="{{specialization}}" data-situational-mod="{{situationalMod}}">
+<div class="witch-iron chat-card witch-iron-roll" data-hits="{{hits}}" data-actor="{{actor.name}}" {{#if isCombatCheck}}data-combat-check="true"{{/if}} data-actor-id="{{actorId}}" data-roll="{{roll.total}}" data-target="{{targetValue}}" data-additional-hits="{{additionalHits}}" data-label="{{label}}" data-specialization="{{specialization}}" data-situational-mod="{{situationalMod}}" data-luck-spent="{{luckSpent}}">
   <header class="card-header">
     <img src="{{actor.img}}" title="{{actor.name}}" width="36" height="36"/>
     <h3>


### PR DESCRIPTION
## Summary
- allow players to request roll updates that the GM processes
- hook GM listeners for `roll-update-request`
- refresh Quarrel cards when rolls change for everyone

## Testing
- `node --check scripts/quarrel.js`
- `node --check scripts/actor.js`


------
https://chatgpt.com/codex/tasks/task_e_6840ba7d878c832d9959b429fb127d21