### PR TITLE
Improve modifier dialog and roll tooltips

### DIFF
--- a/scripts/modifier-dialog.js
+++ b/scripts/modifier-dialog.js
@@ -45,21 +45,21 @@ export async function openModifierDialog(actor, {title="Roll Modifiers", default
   if (blind > 0) {
     const blindPenalty = -10 * blind;
     conditionRows.push(`
-        <div class="form-group modifier-row ${blind ? 'selected' : ''}" data-toggle="useBlind">
+        <div class="form-group modifier-row" data-toggle="useBlind">
           <label>Blind</label>
           <span class="modifier-value">${blindPenalty}%</span>
           <input type="number" name="blindRating" value="${blind}" min="0" />
-          <input type="hidden" name="useBlind" value="${blind ? 1 : 0}">
+          <input type="hidden" name="useBlind" value="0">
         </div>`);
   }
   if (deaf > 0) {
     const deafPenalty = -10 * deaf;
     conditionRows.push(`
-        <div class="form-group modifier-row ${deaf ? 'selected' : ''}" data-toggle="useDeaf">
+        <div class="form-group modifier-row" data-toggle="useDeaf">
           <label>Deaf</label>
           <span class="modifier-value">${deafPenalty}%</span>
           <input type="number" name="deafRating" value="${deaf}" min="0" />
-          <input type="hidden" name="useDeaf" value="${deaf ? 1 : 0}">
+          <input type="hidden" name="useDeaf" value="0">
         </div>`);
   }
   if (pain > 0) {
@@ -99,11 +99,11 @@ export async function openModifierDialog(actor, {title="Roll Modifiers", default
       const locLabel = loc.replace(/([A-Z])/g, ' $1');
       const traumaPenalty = -20 * val;
       conditionRows.push(`
-        <div class="form-group modifier-row selected" data-toggle="useTrauma-${loc}">
+        <div class="form-group modifier-row" data-toggle="useTrauma-${loc}">
           <label>Trauma (${locLabel})</label>
           <span class="modifier-value">${traumaPenalty}%</span>
           <input type="number" name="traumaRating-${loc}" value="${val}" min="0" />
-          <input type="hidden" name="useTrauma-${loc}" value="1">
+          <input type="hidden" name="useTrauma-${loc}" value="0">
         </div>`);
     }
   }

--- a/templates/chat/quarrel-result.hbs
+++ b/templates/chat/quarrel-result.hbs
@@ -32,7 +32,7 @@
                         {{/if}}
                     {{/if}}
                 </div>
-                <span class="hits">Hits: {{result.initiatorHits}}</span>
+                <span class="hits" data-target="{{result.initiatorTarget}}" data-situational-mod="{{result.initiatorSituationalMod}}" data-additional-hits="{{result.initiatorAdditionalHits}}">Hits: {{result.initiatorHits}}</span>
                 <span class="outcome {{result.initiatorOutcome}}">{{outcomeLocalize result.initiatorOutcome}}</span>
                 {{#if (gt result.netHits 0)}}
                 <span class="net-hits positive net-hits-display" data-character="initiator">Net Hits: <span class="hits-value">+{{result.netHits}}</span></span>
@@ -51,7 +51,7 @@
                     <img class="token-image" src="icons/svg/mystery-man.svg" data-actor="{{result.responderName}}">
                     {{/if}}
                 </div>
-                <span class="hits">Hits: {{result.responderHits}}</span>
+                <span class="hits" data-target="{{result.responderTarget}}" data-situational-mod="{{result.responderSituationalMod}}" data-additional-hits="{{result.responderAdditionalHits}}">Hits: {{result.responderHits}}</span>
                 <span class="outcome {{result.responderOutcome}}">{{outcomeLocalize result.responderOutcome}}</span>
                 {{#if (lt result.netHits 0)}}
                 <span class="net-hits positive net-hits-display" data-character="responder">Net Hits: <span class="hits-value">+{{abs result.netHits}}</span></span>

--- a/templates/chat/roll-card.hbs
+++ b/templates/chat/roll-card.hbs
@@ -18,7 +18,7 @@
       </div>
       
       <div class="test-details">
-        <div class="target">Target: {{targetValue}}</div>
+        <div class="target" data-target="{{targetValue}}" data-situational-mod="{{situationalMod}}" data-additional-hits="{{additionalHits}}">Target: {{targetValue}}</div>
         <div class="outcome">
           {{#if isCriticalSuccess}}
             Critical Success!
@@ -30,7 +30,7 @@
             Failure
           {{/if}}
         </div>
-        <div class="hits">Hits: {{hits}}</div>
+        <div class="hits" data-target="{{targetValue}}" data-situational-mod="{{situationalMod}}" data-additional-hits="{{additionalHits}}">Hits: {{hits}}</div>
         {{#if specialization}}
         <div class="specialization">Specialization: {{specialization}}</div>
         {{/if}}


### PR DESCRIPTION
## Summary
- default condition modifiers now only auto-select Pain and Prone
- store roll modifier info for quarrels
- display modifier breakdown on check and quarrel cards on hover
- preselect Target Prone when a targeted actor is prone

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840bf561e5c832dbef64231b2b48c27