### PR TITLE
Style chat roll buttons

### DIFF
--- a/styles/witch-iron.css
+++ b/styles/witch-iron.css
@@ -1800,6 +1800,23 @@ button.roll-skill:hover {
   margin: 0;
 }
 
+.witch-iron.chat-card .dice-result {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.witch-iron.chat-card .dice-result .roll-actions {
+  margin-left: auto;
+  display: flex;
+  gap: 5px;
+}
+
+.witch-iron.chat-card .roll-actions button {
+  font-size: 0.5em;
+  padding: 2px 4px;
+}
+
 .witch-iron.chat-card .test-details {
   display: grid;
   gap: 5px;

--- a/templates/chat/roll-card.hbs
+++ b/templates/chat/roll-card.hbs
@@ -14,6 +14,11 @@
       <div class="dice-roll">
         <div class="dice-result">
           <h4 class="dice-total">{{roll.total}}</h4>
+          <div class="roll-actions">
+            <button type="button" class="reverse-btn">Reverse</button>
+            <button type="button" class="reroll-btn">Reroll</button>
+            <button type="button" class="luck-btn">Luck</button>
+          </div>
         </div>
       </div>
       
@@ -45,10 +50,5 @@
       <span class="value">{{roll.formula}}</span>
     </div>
     {{/if}}
-    <div class="roll-actions">
-      <button type="button" class="reverse-btn">Reverse</button>
-      <button type="button" class="reroll-btn">Reroll</button>
-      <button type="button" class="luck-btn">Luck</button>
-    </div>
   </footer>
 </div>


### PR DESCRIPTION
## Summary
- tuck Reverse/Reroll/Luck buttons next to the roll result
- shrink roll action buttons and adjust spacing

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840ca13ee8c832da2465fba21603989