### PR TITLE
Style chat roll buttons

### DIFF
--- a/styles/witch-iron.css
+++ b/styles/witch-iron.css
@@ -1783,8 +1783,14 @@ button.roll-skill:hover {
 .witch-iron.chat-card .roll-result {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   gap: 10px;
+}
+
+.witch-iron.chat-card .roll-header {
+  display: flex;
+  align-items: center;
+  width: 100%;
 }
 
 .witch-iron.chat-card .dice-roll {
@@ -1798,6 +1804,26 @@ button.roll-skill:hover {
   font-size: 2em;
   font-weight: bold;
   margin: 0;
+}
+
+.witch-iron.chat-card .dice-result {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+
+.witch-iron.chat-card .roll-actions {
+  margin-left: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 5px;
+}
+
+.witch-iron.chat-card .roll-actions button {
+  font-size: 0.5em;
+  padding: 2px 4px;
 }
 
 .witch-iron.chat-card .test-details {

--- a/templates/chat/roll-card.hbs
+++ b/templates/chat/roll-card.hbs
@@ -11,9 +11,16 @@
 
   <div class="card-content">
     <div class="roll-result {{#if isCriticalSuccess}}critical-success{{else if isFumble}}fumble{{else if isSuccess}}success{{else}}failure{{/if}}">
-      <div class="dice-roll">
-        <div class="dice-result">
-          <h4 class="dice-total">{{roll.total}}</h4>
+      <div class="roll-header">
+        <div class="dice-roll">
+          <div class="dice-result">
+            <h4 class="dice-total">{{roll.total}}</h4>
+          </div>
+        </div>
+        <div class="roll-actions">
+          <button type="button" class="reverse-btn">Reverse</button>
+          <button type="button" class="reroll-btn">Reroll</button>
+          <button type="button" class="luck-btn">Luck</button>
         </div>
       </div>
       
@@ -45,10 +52,5 @@
       <span class="value">{{roll.formula}}</span>
     </div>
     {{/if}}
-    <div class="roll-actions">
-      <button type="button" class="reverse-btn">Reverse</button>
-      <button type="button" class="reroll-btn">Reroll</button>
-      <button type="button" class="luck-btn">Luck</button>
-    </div>
   </footer>
 </div>


### PR DESCRIPTION
## Summary
- tuck Reverse/Reroll/Luck buttons next to the roll result
- shrink roll action buttons and adjust spacing
- move roll action buttons outside the dice box and stack them vertically

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840ca13ee8c832da2465fba21603989