### PR TITLE
Adjust roll card button layout

### DIFF
--- a/styles/witch-iron.css
+++ b/styles/witch-iron.css
@@ -1803,12 +1803,25 @@ button.roll-skill:hover {
 .witch-iron.chat-card .dice-result {
   display: flex;
   align-items: center;
+  min-width: 60px;
   width: 100%;
 }
 
-.witch-iron.chat-card .dice-result .roll-actions {
+.witch-iron.chat-card .roll-header {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: 10px;
+  font-weight: normal;
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.witch-iron.chat-card .roll-actions {
   margin-left: auto;
   display: flex;
+  flex-direction: column;
   gap: 5px;
 }
 

--- a/templates/chat/roll-card.hbs
+++ b/templates/chat/roll-card.hbs
@@ -11,14 +11,16 @@
 
   <div class="card-content">
     <div class="roll-result {{#if isCriticalSuccess}}critical-success{{else if isFumble}}fumble{{else if isSuccess}}success{{else}}failure{{/if}}">
-      <div class="dice-roll">
-        <div class="dice-result">
-          <h4 class="dice-total">{{roll.total}}</h4>
-          <div class="roll-actions">
-            <button type="button" class="reverse-btn">Reverse</button>
-            <button type="button" class="reroll-btn">Reroll</button>
-            <button type="button" class="luck-btn">Luck</button>
+      <div class="roll-header">
+        <div class="dice-roll">
+          <div class="dice-result">
+            <h4 class="dice-total">{{roll.total}}</h4>
           </div>
+        </div>
+        <div class="roll-actions">
+          <button type="button" class="reverse-btn">Reverse</button>
+          <button type="button" class="reroll-btn">Reroll</button>
+          <button type="button" class="luck-btn">Luck</button>
         </div>
       </div>
       


### PR DESCRIPTION
## Summary
- move Reverse/Reroll/Luck buttons into a new `roll-header` container
- style roll header and actions to stack buttons vertically
- widen dice result element so three digits fit on one row

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840cdf8f8b0832dae5e38faef449070