### PR TITLE
Refine roll header layout

### DIFF
--- a/styles/witch-iron.css
+++ b/styles/witch-iron.css
@@ -1809,8 +1809,10 @@ button.roll-skill:hover {
 }
 
 .witch-iron.chat-card .roll-header {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
   align-items: center;
+  justify-items: center;
   width: 100%;
   gap: 10px;
   font-weight: normal;

--- a/templates/chat/roll-card.hbs
+++ b/templates/chat/roll-card.hbs
@@ -12,6 +12,7 @@
   <div class="card-content">
     <div class="roll-result {{#if isCriticalSuccess}}critical-success{{else if isFumble}}fumble{{else if isSuccess}}success{{else}}failure{{/if}}">
       <div class="roll-header">
+        <div class="spacer"></div>
         <div class="dice-roll">
           <div class="dice-result">
             <h4 class="dice-total">{{roll.total}}</h4>


### PR DESCRIPTION
## Summary
- tweak roll header to use a three-column grid
- add spacer div so roll result centers between action buttons

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840db6de668832d920c4a9762a1aa76