### PR TITLE
Fix mob casualty logic for small groups

### DIFF
--- a/scripts/hit-location.js
+++ b/scripts/hit-location.js
@@ -525,7 +525,7 @@ export class HitLocationSelector {
         const soakText = `${defenderAbilityBonus}(${armorBonus})`;   // Use effective armor bonus
 
         // --- Mob handling: convert damage into body losses ---
-        if (defenderActor?.system?.mob?.isMob?.value) {
+        if (defenderActor?.system?.mob?.isMob?.value && (defenderActor.system.mob.bodies.value || 0) >= 5) {
             const currentBodies = defenderActor.system.mob.bodies.value || 0;
             const bodiesKilled = Math.floor(netDamage / 5);
             const remainingBodies = Math.max(0, currentBodies - bodiesKilled);


### PR DESCRIPTION
## Summary
- treat mobs as regular monsters for combat injuries until they reach 5 bodies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840e28b13f8832da5118e85cdc44a81