### PR TITLE
Update monster size to scale tokens

### DIFF
--- a/scripts/ghost-tokens.js
+++ b/scripts/ghost-tokens.js
@@ -204,7 +204,9 @@ export async function syncGhostTiles(token, required, overrides = {}) {
   const rad = (rot * Math.PI) / 180;
   const cos = Math.cos(rad);
   const sin = Math.sin(rad);
-  const offsets = computeOffsets(required, 0, formation).map(o => ({
+  const baseOffsets = computeOffsets(required, 0, formation)
+    .map(o => ({ x: o.x * doc.width, y: o.y * doc.height }));
+  const offsets = baseOffsets.map(o => ({
     x: o.x * cos - o.y * sin,
     y: o.x * sin + o.y * cos
   }));


### PR DESCRIPTION
## Summary
- monster sheet size selection now updates token dimensions
- mob ghost tokens respect new token size

## Testing
- `node --check scripts/monster-sheet.js`
- `node --check scripts/ghost-tokens.js`


------
https://chatgpt.com/codex/tasks/task_e_6840e49e6830832db10de4d8cb372908