### PR TITLE
Update token sizing for mobs

### DIFF
--- a/scripts/ghost-tokens.js
+++ b/scripts/ghost-tokens.js
@@ -204,7 +204,12 @@ export async function syncGhostTiles(token, required, overrides = {}) {
   const rad = (rot * Math.PI) / 180;
   const cos = Math.cos(rad);
   const sin = Math.sin(rad);
-  const offsets = computeOffsets(required, 0, formation).map(o => ({
+  const doc = token.document ?? token;
+  const baseOffsets = computeOffsets(required, 0, formation).map(o => ({
+    x: o.x * doc.width,
+    y: o.y * doc.height
+  }));
+  const offsets = baseOffsets.map(o => ({
     x: o.x * cos - o.y * sin,
     y: o.x * sin + o.y * cos
   }));
@@ -216,7 +221,6 @@ export async function syncGhostTiles(token, required, overrides = {}) {
   }
 
   const grid = canvas.scene.grid.size;
-  const doc = token.document ?? token;
   const width = doc.width * grid;
   const height = doc.height * grid;
   const xBase = overrides.x ?? token.x;

--- a/scripts/monster-sheet.js
+++ b/scripts/monster-sheet.js
@@ -5,7 +5,7 @@
 import { manualQuarrel } from "./quarrel.js";
 import { createItem } from "./utils.js";
 import { openModifierDialog } from "./modifier-dialog.js";
-import { FORMATION_SHAPES } from "./ghost-tokens.js";
+import { FORMATION_SHAPES, syncGhostTiles } from "./ghost-tokens.js";
 
 /**
  * Monster sheet class for the Witch Iron system
@@ -654,14 +654,50 @@ export class WitchIronMonsterSheet extends ActorSheet {
   async _onSizeChange(event) {
     const select = event.currentTarget;
     const newSize = select.value;
-    
+
 //////     console.log(`Size changed to ${newSize}`);
-    
+
     try {
       // Update the actor with the new size value
       await this.actor.update({ 'system.stats.size.value': newSize });
-//////       console.log("Updated actor with new size:", newSize);
-      
+
+      const sizeMap = {
+        tiny: { width: 1, height: 1, scale: 1 / 3 },
+        small: { width: 1, height: 1, scale: 2 / 3 },
+        medium: { width: 1, height: 1, scale: 1 },
+        large: { width: 2, height: 2, scale: 1 },
+        huge: { width: 4, height: 4, scale: 1 },
+        gigantic: { width: 8, height: 8, scale: 1 }
+      };
+      const data = sizeMap[newSize] || sizeMap.medium;
+
+      // Update the prototype token
+      await this.actor.update({
+        'prototypeToken.width': data.width,
+        'prototypeToken.height': data.height,
+        'prototypeToken.texture.scaleX': data.scale,
+        'prototypeToken.texture.scaleY': data.scale
+      });
+
+      // Update active tokens on the canvas
+      const active = this.actor.getActiveTokens();
+      const updates = active.map(t => ({
+        _id: t.id,
+        width: data.width,
+        height: data.height,
+        'texture.scaleX': data.scale,
+        'texture.scaleY': data.scale
+      }));
+      if (updates.length) await canvas.scene.updateEmbeddedDocuments('Token', updates);
+
+      // Adjust any ghost tiles for mob leaders
+      const bodies = this.actor.system.mob?.bodies?.value || 1;
+      for (const token of active) {
+        if (token.getFlag('witch-iron', 'isMobLeader')) {
+          await syncGhostTiles(token, bodies - 1);
+        }
+      }
+
       // Force update for all derived stats
       const html = $(this.element);
       this._updateDerivedDisplay(html);


### PR DESCRIPTION
## Summary
- adjust ghost tile spacing calculation
- resize mob ghost tokens when monster size changes

## Testing
- `node --check scripts/monster-sheet.js`
- `node --check scripts/ghost-tokens.js`


------
https://chatgpt.com/codex/tasks/task_e_6840e49e6830832db10de4d8cb372908