### PR TITLE
Fix ghost token scaling for small sizes

### DIFF
--- a/scripts/ghost-tokens.js
+++ b/scripts/ghost-tokens.js
@@ -221,8 +221,10 @@ export async function syncGhostTiles(token, required, overrides = {}) {
   }
 
   const grid = canvas.scene.grid.size;
-  const width = doc.width * grid;
-  const height = doc.height * grid;
+  const scaleX = doc.texture?.scaleX ?? 1;
+  const scaleY = doc.texture?.scaleY ?? 1;
+  const width = doc.width * grid * scaleX;
+  const height = doc.height * grid * scaleY;
   const xBase = overrides.x ?? token.x;
   const yBase = overrides.y ?? token.y;
   const rotation = overrides.rotation ?? token.rotation;

--- a/scripts/monster-sheet.js
+++ b/scripts/monster-sheet.js
@@ -693,8 +693,9 @@ export class WitchIronMonsterSheet extends ActorSheet {
       // Adjust any ghost tiles for mob leaders
       const bodies = this.actor.system.mob?.bodies?.value || 1;
       for (const token of active) {
-        if (token.getFlag('witch-iron', 'isMobLeader')) {
-          await syncGhostTiles(token, bodies - 1);
+        const doc = token.document ?? token;
+        if (doc.getFlag('witch-iron', 'isMobLeader')) {
+          await syncGhostTiles(doc, bodies - 1);
         }
       }
       // Force update for all derived stats


### PR DESCRIPTION
## Summary
- ensure active tokens retrieved from the monster sheet use their document when syncing ghost tiles
- scale ghost token tile dimensions using the token's texture scaling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840e74b7fbc832d995c4b829e80cb85