### PR TITLE
Add collapsible section for zero-rating conditions

### DIFF
--- a/scripts/monster-sheet.js
+++ b/scripts/monster-sheet.js
@@ -148,24 +148,34 @@ export class WitchIronMonsterSheet extends ActorSheet {
     const witchIronConfig = CONFIG.WITCH_IRON || {};
     context.config = witchIronConfig;
 
-    // Prepare conditions for the #each helper
+    // Prepare conditions for display
     context.conditions = {};
+    context.currentConditions = [];
+    context.zeroConditions = [];
     const conditionsData = actorData.system.conditions || {};
     for (const condKey in conditionsData) {
       if (condKey === "trauma" && typeof conditionsData.trauma === "object") {
         for (const loc in conditionsData.trauma) {
           const key = `trauma.${loc}`;
           const labelLoc = loc.replace(/([A-Z])/g, " $1");
-          context.conditions[key] = {
+          const value = conditionsData.trauma[loc].value;
+          const condObj = {
+            key,
             label: `Trauma (${this.capitalize(labelLoc)})`,
-            value: conditionsData.trauma[loc].value
+            value
           };
+          context.conditions[key] = condObj;
+          (value > 0 ? context.currentConditions : context.zeroConditions).push(condObj);
         }
       } else {
-        context.conditions[condKey] = {
+        const value = conditionsData[condKey].value;
+        const condObj = {
+          key: condKey,
           label: this.capitalize(condKey),
-          value: conditionsData[condKey].value
+          value
         };
+        context.conditions[condKey] = condObj;
+        (value > 0 ? context.currentConditions : context.zeroConditions).push(condObj);
       }
     }
 

--- a/styles/witch-iron.css
+++ b/styles/witch-iron.css
@@ -3765,3 +3765,23 @@ button.roll-skill:hover {
   background: rgba(50, 50, 50, 0.8);
   color: var(--color-surface-light);
 }
+
+/* Collapsible list for zero rating conditions */
+.witch-iron.sheet .conditions-list details.zero-conditions summary.btn {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  background-color: var(--tertiary-color);
+  border: 1px solid var(--color-border);
+  padding: 0.5em 0.75em;
+  margin-top: 0.5em;
+  border-radius: 3px;
+}
+.witch-iron.sheet .conditions-list details.zero-conditions .toggle-arrow {
+  margin-right: 0.5em;
+  transition: transform 0.2s ease;
+  transform: rotate(90deg);
+}
+.witch-iron.sheet .conditions-list details.zero-conditions:not([open]) .toggle-arrow {
+  transform: rotate(0deg);
+}

--- a/templates/actors/monster-sheet.hbs
+++ b/templates/actors/monster-sheet.hbs
@@ -285,15 +285,30 @@
             </div>
             <!-- Conditions UI -->
             <div class="conditions-list">
-              <h2>Conditions</h2>
-              {{#each conditions as |condition key|}}
-              <div class="condition-row flexrow" data-condition="{{key}}">
-                <button type="button" class="condition-name cond-quarrel">{{condition.label}}</button>
+              <h2>Current Conditions</h2>
+              {{#each currentConditions}}
+              <div class="condition-row flexrow" data-condition="{{this.key}}">
+                <button type="button" class="condition-name cond-quarrel">{{this.label}}</button>
                 <button type="button" class="cond-minus"><i class="fas fa-minus"></i></button>
-                <input type="number" class="cond-value" value="{{condition.value}}" min="0" />
+                <input type="number" class="cond-value" value="{{this.value}}" min="0" />
                 <button type="button" class="cond-plus"><i class="fas fa-plus"></i></button>
               </div>
               {{/each}}
+
+              <details class="zero-conditions">
+                <summary class="btn">
+                  <i class="fas fa-caret-right toggle-arrow"></i>
+                  Other Conditions
+                </summary>
+                {{#each zeroConditions}}
+                <div class="condition-row flexrow" data-condition="{{this.key}}">
+                  <button type="button" class="condition-name cond-quarrel">{{this.label}}</button>
+                  <button type="button" class="cond-minus"><i class="fas fa-minus"></i></button>
+                  <input type="number" class="cond-value" value="{{this.value}}" min="0" />
+                  <button type="button" class="cond-plus"><i class="fas fa-plus"></i></button>
+                </div>
+                {{/each}}
+              </details>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- split monster condition list into active and zero-rating groups
- make zero-rating conditions collapsible in the injury tab
- style collapsible section

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840f0d623bc832dba98c783ca079c85