### PR TITLE
Add hit location HUD

### DIFF
--- a/scripts/hit-location-hud.js
+++ b/scripts/hit-location-hud.js
@@ -1,0 +1,35 @@
+export class HitLocationHUD {
+  static init() {
+    console.log('Witch Iron | Hit Location HUD initializing');
+    this.container = document.createElement('div');
+    this.container.id = 'hit-location-hud';
+    document.body.appendChild(this.container);
+
+    Hooks.on('controlToken', (token, controlled) => {
+      if (controlled) {
+        HitLocationHUD.render(token.actor);
+      } else if (canvas.tokens.controlled.length === 0) {
+        HitLocationHUD.clear();
+      }
+    });
+
+    Hooks.on('updateActor', (actor) => {
+      if (canvas.tokens.controlled.some(t => t.actor === actor)) {
+        HitLocationHUD.render(actor);
+      }
+    });
+  }
+
+  static clear() {
+    if (this.container) this.container.innerHTML = '';
+  }
+
+  static async render(actor) {
+    if (!this.container) return;
+    const injuries = actor.items.filter(i => i.type === 'injury');
+    const conditions = actor.system?.conditions || {};
+    const data = { actor, injuries, conditions };
+    const html = await renderTemplate('systems/witch-iron/templates/hud/hit-location-hud.hbs', data);
+    this.container.innerHTML = html;
+  }
+}

--- a/scripts/witch-iron.js
+++ b/scripts/witch-iron.js
@@ -14,6 +14,7 @@ import { WitchIronInjurySheet } from "./injury-sheet.js";
 import { initQuarrel, manualQuarrel, quarrelTracker } from "./quarrel.js";
 import { HitLocationSelector } from "./hit-location.js";
 import { InjuryTables } from "./injury-tables.js";
+import { HitLocationHUD } from "./hit-location-hud.js";
 import { registerCommonHandlebarsHelpers } from "./handlebars-helpers.js";
 import { FORMATION_SHAPES } from "./ghost-tokens.js";
 import "./ghost-tokens.js";
@@ -205,6 +206,9 @@ Hooks.once("init", function() {
 Hooks.once("ready", function() {
   // Any code that should run when Foundry is fully loaded
   console.log("Witch Iron | System Ready");
+
+  // Initialize the hit location HUD
+  HitLocationHUD.init();
   
   // Debug: Log all actors and their types
   console.log("ACTOR TYPES DEBUG:");
@@ -426,4 +430,4 @@ Hooks.on("renderDialog", (dialog, html, data) => {
 });
 
 // Export classes for module use
-export { WitchIronActor, WitchIronItem, WitchIronDescendantSheet, WitchIronMonsterSheet, WitchIronInjurySheet };
+export { WitchIronActor, WitchIronItem, WitchIronDescendantSheet, WitchIronMonsterSheet, WitchIronInjurySheet, HitLocationHUD };

--- a/styles/hit-location-hud.css
+++ b/styles/hit-location-hud.css
@@ -1,0 +1,36 @@
+/* Hit Location HUD Styles */
+#hit-location-hud {
+  position: absolute;
+  left: 10px;
+  bottom: 10px;
+  width: 260px;
+  background: rgba(0, 0, 0, 0.75);
+  color: #f5f3e6;
+  font-family: var(--witchiron-font, serif);
+  padding: 8px;
+  border-radius: 5px;
+  z-index: 100;
+}
+
+#hit-location-hud h3 {
+  margin: 0 0 5px 0;
+  text-align: center;
+}
+
+#hit-location-hud ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+#hit-location-hud li {
+  font-size: 0.9em;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 2px;
+}
+
+#hit-location-hud li.lost {
+  opacity: 0.5;
+  text-decoration: line-through;
+}

--- a/system.json
+++ b/system.json
@@ -22,6 +22,7 @@
     "styles/card-common.css",
     "styles/combat-card.css",
     "styles/hit-location.css",
+    "styles/hit-location-hud.css",
     "styles/injury-card.css",
     "styles/condition-card.css",
     "styles/casualty-cards.css"

--- a/templates/hud/hit-location-hud.hbs
+++ b/templates/hud/hit-location-hud.hbs
@@ -1,0 +1,45 @@
+<div class="hit-location-hud-content">
+  {{#if actor}}
+  <h3>{{actor.name}}</h3>
+  <ul>
+    <li class="location head {{#if actor.system.anatomy.head.lost}}lost{{/if}}">
+      <span>Head</span>
+      <span>{{actor.system.anatomy.head.armor}}/{{actor.system.anatomy.head.soak}}</span>
+    </li>
+    <li class="location torso {{#if actor.system.anatomy.torso.lost}}lost{{/if}}">
+      <span>Torso</span>
+      <span>{{actor.system.anatomy.torso.armor}}/{{actor.system.anatomy.torso.soak}}</span>
+    </li>
+    <li class="location left-arm {{#if actor.system.anatomy.leftArm.lost}}lost{{/if}}">
+      <span>Left Arm</span>
+      <span>{{actor.system.anatomy.leftArm.armor}}/{{actor.system.anatomy.leftArm.soak}}</span>
+    </li>
+    <li class="location right-arm {{#if actor.system.anatomy.rightArm.lost}}lost{{/if}}">
+      <span>Right Arm</span>
+      <span>{{actor.system.anatomy.rightArm.armor}}/{{actor.system.anatomy.rightArm.soak}}</span>
+    </li>
+    <li class="location left-leg {{#if actor.system.anatomy.leftLeg.lost}}lost{{/if}}">
+      <span>Left Leg</span>
+      <span>{{actor.system.anatomy.leftLeg.armor}}/{{actor.system.anatomy.leftLeg.soak}}</span>
+    </li>
+    <li class="location right-leg {{#if actor.system.anatomy.rightLeg.lost}}lost{{/if}}">
+      <span>Right Leg</span>
+      <span>{{actor.system.anatomy.rightLeg.armor}}/{{actor.system.anatomy.rightLeg.soak}}</span>
+    </li>
+  </ul>
+  <h4>Conditions</h4>
+  <ul>
+    {{#each conditions}}
+    <li>{{capitalize key}}: {{this.value}}</li>
+    {{/each}}
+  </ul>
+  <h4>Injuries</h4>
+  <ul>
+    {{#each injuries}}
+    <li>{{name}}</li>
+    {{/each}}
+  </ul>
+  {{else}}
+  <p>No actor selected</p>
+  {{/if}}
+</div>


### PR DESCRIPTION
## Summary
- introduce a new HUD overlay displaying injuries and conditions
- style the overlay and include new template
- initialize HUD when the system is ready

## Testing
- `node --check scripts/hit-location-hud.js`
- `node --check scripts/witch-iron.js`


------
https://chatgpt.com/codex/tasks/task_e_6840f2158154832d8679cd4fd54ffdc0