### PR TITLE
Add hit location HUD overlay enhancements

### DIFF
--- a/scripts/hit-location-hud.js
+++ b/scripts/hit-location-hud.js
@@ -1,0 +1,65 @@
+import { quarrelTracker } from "./quarrel.js";
+
+export class HitLocationHUD {
+  static init() {
+    console.log('Witch Iron | Hit Location HUD initializing');
+    this.container = document.createElement('div');
+    this.container.id = 'hit-location-hud';
+    document.body.appendChild(this.container);
+    this.activeActor = null;
+
+    Hooks.on('controlToken', (token, controlled) => {
+      if (controlled && token.isOwner) {
+        this.activeActor = token.actor;
+        HitLocationHUD.render(token.actor);
+      } else if (canvas.tokens.controlled.length) {
+        const last = canvas.tokens.controlled.at(-1);
+        if (last?.isOwner) {
+          this.activeActor = last.actor;
+          HitLocationHUD.render(last.actor);
+        }
+      } else {
+        this.activeActor = null;
+        HitLocationHUD.clear();
+      }
+    });
+
+    Hooks.on('updateActor', (actor) => {
+      if (this.activeActor?.id === actor.id) {
+        HitLocationHUD.render(actor);
+      }
+    });
+
+    Hooks.on('updateItem', (item) => {
+      const actor = item.parent;
+      if (actor && this.activeActor?.id === actor.id) {
+        HitLocationHUD.render(actor);
+      }
+    });
+  }
+
+  static clear() {
+    if (this.container) this.container.innerHTML = '';
+  }
+
+  static async render(actor) {
+    if (!this.container || !actor) return;
+    const injuries = actor.items.filter(i => i.type === 'injury');
+    const condObj = actor.system?.conditions || {};
+
+    const conditions = [];
+    for (const [key, data] of Object.entries(condObj)) {
+      const value = Number(data?.value || 0);
+      if (key !== 'trauma' && value >= 1) {
+        conditions.push({ key, value, icon: quarrelTracker.CONDITION_ICONS[key] });
+      }
+    }
+
+    const trauma = condObj.trauma || {};
+    const anatomy = actor.system?.anatomy || {};
+
+    const data = { actor, injuries, conditions, trauma, anatomy };
+    const html = await renderTemplate('systems/witch-iron/templates/hud/hit-location-hud.hbs', data);
+    this.container.innerHTML = html;
+  }
+}

--- a/scripts/witch-iron.js
+++ b/scripts/witch-iron.js
@@ -14,6 +14,7 @@ import { WitchIronInjurySheet } from "./injury-sheet.js";
 import { initQuarrel, manualQuarrel, quarrelTracker } from "./quarrel.js";
 import { HitLocationSelector } from "./hit-location.js";
 import { InjuryTables } from "./injury-tables.js";
+import { HitLocationHUD } from "./hit-location-hud.js";
 import { registerCommonHandlebarsHelpers } from "./handlebars-helpers.js";
 import { FORMATION_SHAPES } from "./ghost-tokens.js";
 import "./ghost-tokens.js";
@@ -205,6 +206,9 @@ Hooks.once("init", function() {
 Hooks.once("ready", function() {
   // Any code that should run when Foundry is fully loaded
   console.log("Witch Iron | System Ready");
+
+  // Initialize the hit location HUD
+  HitLocationHUD.init();
   
   // Debug: Log all actors and their types
   console.log("ACTOR TYPES DEBUG:");
@@ -426,4 +430,4 @@ Hooks.on("renderDialog", (dialog, html, data) => {
 });
 
 // Export classes for module use
-export { WitchIronActor, WitchIronItem, WitchIronDescendantSheet, WitchIronMonsterSheet, WitchIronInjurySheet };
+export { WitchIronActor, WitchIronItem, WitchIronDescendantSheet, WitchIronMonsterSheet, WitchIronInjurySheet, HitLocationHUD };

--- a/styles/hit-location-hud.css
+++ b/styles/hit-location-hud.css
@@ -1,0 +1,99 @@
+/* Hit Location HUD Styles */
+
+#hit-location-hud h3 {
+  margin: 0 0 5px 0;
+  text-align: center;
+}
+
+#hit-location-hud ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+#hit-location-hud li {
+  font-size: 0.9em;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 2px;
+}
+
+#hit-location-hud li.lost {
+  opacity: 0.5;
+  text-decoration: line-through;
+}
+
+/* New HUD Layout */
+#hit-location-hud {
+  position: absolute;
+  left: 10px;
+  bottom: 10px;
+  width: 260px;
+  background: rgba(0, 0, 0, 0.75);
+  color: #f5f3e6;
+  font-family: var(--witchiron-font, serif);
+  padding: 8px;
+  border-radius: 5px;
+  z-index: 100;
+}
+
+#hit-location-hud .conditions {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+#hit-location-hud .conditions .cond {
+  position: relative;
+}
+
+#hit-location-hud .conditions img {
+  width: 20px;
+  height: 20px;
+}
+
+#hit-location-hud .conditions .value {
+  position: absolute;
+  bottom: -4px;
+  right: -4px;
+  font-size: 0.75em;
+}
+
+#hit-location-hud .hud-body {
+  position: relative;
+  width: 200px;
+  height: 280px;
+  margin: 0 auto;
+}
+
+#hit-location-hud .hud-body .body-outline svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+#hit-location-hud .location-value {
+  position: absolute;
+  text-align: center;
+  font-size: 0.8em;
+  pointer-events: none;
+}
+
+#hit-location-hud .location-value .trauma {
+  display: block;
+  font-size: 0.75em;
+}
+
+#hit-location-hud .lost {
+  opacity: 0.4;
+}
+
+#hit-location-hud .head-label { top: 20px; left: 118px; }
+#hit-location-hud .torso-label { top: 105px; left: 118px; }
+#hit-location-hud .left-arm-label { top: 145px; left: 38px; }
+#hit-location-hud .right-arm-label { top: 145px; left: 185px; }
+#hit-location-hud .left-leg-label { top: 275px; left: 38px; }
+#hit-location-hud .right-leg-label { top: 275px; left: 185px; }

--- a/system.json
+++ b/system.json
@@ -22,6 +22,7 @@
     "styles/card-common.css",
     "styles/combat-card.css",
     "styles/hit-location.css",
+    "styles/hit-location-hud.css",
     "styles/injury-card.css",
     "styles/condition-card.css",
     "styles/casualty-cards.css"

--- a/templates/hud/hit-location-hud.hbs
+++ b/templates/hud/hit-location-hud.hbs
@@ -1,0 +1,69 @@
+<div class="hit-location-hud-content">
+  {{#if actor}}
+  <div class="conditions">
+    {{#each conditions}}
+    <div class="cond">
+      <img src="{{icon}}" alt="{{key}}" />
+      <span class="value">{{value}}</span>
+    </div>
+    {{/each}}
+  </div>
+  <h3>{{actor.name}}</h3>
+  <div class="hud-body">
+    <div class="body-outline">
+      <svg viewBox="0 0 200 280" xmlns="http://www.w3.org/2000/svg">
+        <path d="M100,50 C120,50 120,60 120,70 L120,110 C120,130 110,140 100,150 C90,140 80,130 80,110 L80,70 C80,60 80,50 100,50Z" fill="#693731" class="body-part torso-part {{#if anatomy.torso.lost}}lost{{/if}}" />
+        <circle cx="100" cy="35" r="15" fill="#693731" class="body-part head-part {{#if anatomy.head.lost}}lost{{/if}}" />
+        <path d="M80,70 C70,75 55,90 50,110 C45,130 45,140 55,150" stroke="#693731" stroke-width="16" fill="none" class="body-part left-arm-part {{#if anatomy.leftArm.lost}}lost{{/if}}" />
+        <path d="M120,70 C130,75 145,90 150,110 C155,130 155,140 145,150" stroke="#693731" stroke-width="16" fill="none" class="body-part right-arm-part {{#if anatomy.rightArm.lost}}lost{{/if}}" />
+        <path d="M90,150 C85,170 80,190 75,230" stroke="#693731" stroke-width="15" fill="none" class="body-part left-leg-part {{#if anatomy.leftLeg.lost}}lost{{/if}}" />
+        <path d="M110,150 C115,170 120,190 125,230" stroke="#693731" stroke-width="15" fill="none" class="body-part right-leg-part {{#if anatomy.rightLeg.lost}}lost{{/if}}" />
+      </svg>
+    </div>
+    <div class="location-value head-label {{#if anatomy.head.lost}}lost{{/if}}">
+      {{anatomy.head.armor}}/{{anatomy.head.soak}}
+      {{#if trauma.head.value}}
+      <span class="trauma"><i class="fas fa-bone"></i>{{trauma.head.value}}</span>
+      {{/if}}
+    </div>
+    <div class="location-value torso-label {{#if anatomy.torso.lost}}lost{{/if}}">
+      {{anatomy.torso.armor}}/{{anatomy.torso.soak}}
+      {{#if trauma.torso.value}}
+      <span class="trauma"><i class="fas fa-bone"></i>{{trauma.torso.value}}</span>
+      {{/if}}
+    </div>
+    <div class="location-value left-arm-label {{#if anatomy.leftArm.lost}}lost{{/if}}">
+      {{anatomy.leftArm.armor}}/{{anatomy.leftArm.soak}}
+      {{#if trauma.leftArm.value}}
+      <span class="trauma"><i class="fas fa-bone"></i>{{trauma.leftArm.value}}</span>
+      {{/if}}
+    </div>
+    <div class="location-value right-arm-label {{#if anatomy.rightArm.lost}}lost{{/if}}">
+      {{anatomy.rightArm.armor}}/{{anatomy.rightArm.soak}}
+      {{#if trauma.rightArm.value}}
+      <span class="trauma"><i class="fas fa-bone"></i>{{trauma.rightArm.value}}</span>
+      {{/if}}
+    </div>
+    <div class="location-value left-leg-label {{#if anatomy.leftLeg.lost}}lost{{/if}}">
+      {{anatomy.leftLeg.armor}}/{{anatomy.leftLeg.soak}}
+      {{#if trauma.leftLeg.value}}
+      <span class="trauma"><i class="fas fa-bone"></i>{{trauma.leftLeg.value}}</span>
+      {{/if}}
+    </div>
+    <div class="location-value right-leg-label {{#if anatomy.rightLeg.lost}}lost{{/if}}">
+      {{anatomy.rightLeg.armor}}/{{anatomy.rightLeg.soak}}
+      {{#if trauma.rightLeg.value}}
+      <span class="trauma"><i class="fas fa-bone"></i>{{trauma.rightLeg.value}}</span>
+      {{/if}}
+    </div>
+  </div>
+  <h4>Injuries</h4>
+  <ul>
+    {{#each injuries}}
+    <li>{{name}}</li>
+    {{/each}}
+  </ul>
+  {{else}}
+  <p>No actor selected</p>
+  {{/if}}
+</div>


### PR DESCRIPTION
## Summary
- track the currently controlled token and re-render HUD for actor updates
- show armor/soak and trauma values overlayed on body silhouette
- display active conditions with icons in the HUD
- style HUD for new overlay layout

## Testing
- `node --check scripts/hit-location-hud.js`
- `node --check scripts/witch-iron.js`


------
https://chatgpt.com/codex/tasks/task_e_6840f2158154832d8679cd4fd54ffdc0