### PR TITLE
Add condition sort and reposition HUD

### DIFF
--- a/scripts/hit-location-hud.js
+++ b/scripts/hit-location-hud.js
@@ -1,3 +1,22 @@
+const CONDITION_ICONS = {
+  aflame: 'icons/svg/fire.svg',
+  bleed: 'icons/svg/blood.svg',
+  poison: 'icons/svg/poison.svg',
+  stress: 'icons/svg/burst.svg',
+  corruption: 'icons/svg/bone.svg',
+  blind: 'icons/svg/eye.svg',
+  deaf: 'icons/svg/deaf.svg',
+  pain: 'icons/svg/daze.svg'
+};
+
+const FA_ICONS = {
+  fatigue: 'fa-bed',
+  entangle: 'fa-link',
+  helpless: 'fa-skull',
+  stun: 'fa-bolt',
+  prone: 'fa-person-falling'
+};
+
 export class HitLocationHUD {
   static init() {
     console.log('Witch Iron | Hit Location HUD initializing');
@@ -5,17 +24,34 @@ export class HitLocationHUD {
     this.container.id = 'hit-location-hud';
     document.body.appendChild(this.container);
 
+    this.currentActor = null;
+
     Hooks.on('controlToken', (token, controlled) => {
-      if (controlled) {
-        HitLocationHUD.render(token.actor);
-      } else if (canvas.tokens.controlled.length === 0) {
-        HitLocationHUD.clear();
+      if (controlled && token.actor?.isOwner) {
+        this.currentActor = token.actor;
+        this.render(token.actor);
+        return;
+      }
+
+      const owned = canvas.tokens.controlled.filter(t => t.actor?.isOwner);
+      if (owned.length > 0) {
+        this.currentActor = owned[owned.length - 1].actor;
+        this.render(this.currentActor);
+      } else {
+        this.currentActor = null;
+        this.clear();
       }
     });
 
     Hooks.on('updateActor', (actor) => {
-      if (canvas.tokens.controlled.some(t => t.actor === actor)) {
-        HitLocationHUD.render(actor);
+      if (this.currentActor && this.currentActor.id === actor.id) {
+        this.render(actor);
+      }
+    });
+
+    Hooks.on('updateItem', (item) => {
+      if (this.currentActor && item.actor?.id === this.currentActor.id) {
+        this.render(this.currentActor);
       }
     });
   }
@@ -25,10 +61,28 @@ export class HitLocationHUD {
   }
 
   static async render(actor) {
-    if (!this.container) return;
-    const injuries = actor.items.filter(i => i.type === 'injury');
-    const conditions = actor.system?.conditions || {};
-    const data = { actor, injuries, conditions };
+    if (!this.container || !actor) return;
+
+    const anatomy = actor.system?.anatomy || {};
+    const trauma = actor.system?.conditions?.trauma || {};
+
+    const condObj = actor.system?.conditions || {};
+    const entries = Object.entries(condObj).filter(([k]) => k !== 'trauma');
+    entries.sort((a, b) => a[0].localeCompare(b[0]));
+    const conditions = [];
+    for (const [key, data] of entries) {
+      const value = Number(data?.value || 0);
+      if (value >= 1) {
+        conditions.push({
+          key,
+          value,
+          icon: CONDITION_ICONS[key] || null,
+          faIcon: FA_ICONS[key] || 'fa-exclamation-circle'
+        });
+      }
+    }
+
+    const data = { actor, anatomy, trauma, conditions };
     const html = await renderTemplate('systems/witch-iron/templates/hud/hit-location-hud.hbs', data);
     this.container.innerHTML = html;
   }

--- a/styles/hit-location-hud.css
+++ b/styles/hit-location-hud.css
@@ -1,36 +1,77 @@
 /* Hit Location HUD Styles */
 #hit-location-hud {
-  position: absolute;
+  position: fixed;
   left: 10px;
-  bottom: 10px;
-  width: 260px;
-  background: rgba(0, 0, 0, 0.75);
+  bottom: 150px;
+  width: 25vw;
+  height: 25vh;
+  pointer-events: none;
+  z-index: 100;
   color: #f5f3e6;
   font-family: var(--witchiron-font, serif);
-  padding: 8px;
-  border-radius: 5px;
-  z-index: 100;
 }
 
-#hit-location-hud h3 {
-  margin: 0 0 5px 0;
+#hit-location-hud .body-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+#hit-location-hud .body-outline svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+#hit-location-hud .location-value {
+  position: absolute;
+  font-size: 0.85em;
   text-align: center;
+  line-height: 1.1;
 }
 
-#hit-location-hud ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+#hit-location-hud .location-value .trauma {
+  display: block;
+  color: #e04b4b;
+  font-size: 0.75em;
 }
 
-#hit-location-hud li {
-  font-size: 0.9em;
+#hit-location-hud .location-value.head { top: 10px; left: 120px; }
+#hit-location-hud .location-value.torso { top: 95px; left: 120px; }
+#hit-location-hud .location-value.leftArm { top: 135px; left: 45px; }
+#hit-location-hud .location-value.rightArm { top: 135px; left: 180px; }
+#hit-location-hud .location-value.leftLeg { top: 255px; left: 55px; }
+#hit-location-hud .location-value.rightLeg { top: 255px; left: 170px; }
+
+#hit-location-hud .conditions {
+  position: absolute;
+  top: 0;
+  right: 0;
   display: flex;
-  justify-content: space-between;
-  margin-bottom: 2px;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  flex-wrap: nowrap;
 }
 
-#hit-location-hud li.lost {
-  opacity: 0.5;
-  text-decoration: line-through;
+#hit-location-hud .condition {
+  position: relative;
+  width: 24px;
+  height: 24px;
+}
+
+#hit-location-hud .condition img,
+#hit-location-hud .condition i {
+  width: 100%;
+  height: 100%;
+}
+
+#hit-location-hud .condition .value {
+  position: absolute;
+  bottom: -4px;
+  right: -4px;
+  background: rgba(0, 0, 0, 0.75);
+  border-radius: 8px;
+  font-size: 0.65em;
+  padding: 0 3px;
 }

--- a/templates/hud/hit-location-hud.hbs
+++ b/templates/hud/hit-location-hud.hbs
@@ -1,45 +1,62 @@
-<div class="hit-location-hud-content">
-  {{#if actor}}
-  <h3>{{actor.name}}</h3>
-  <ul>
-    <li class="location head {{#if actor.system.anatomy.head.lost}}lost{{/if}}">
-      <span>Head</span>
-      <span>{{actor.system.anatomy.head.armor}}/{{actor.system.anatomy.head.soak}}</span>
-    </li>
-    <li class="location torso {{#if actor.system.anatomy.torso.lost}}lost{{/if}}">
-      <span>Torso</span>
-      <span>{{actor.system.anatomy.torso.armor}}/{{actor.system.anatomy.torso.soak}}</span>
-    </li>
-    <li class="location left-arm {{#if actor.system.anatomy.leftArm.lost}}lost{{/if}}">
-      <span>Left Arm</span>
-      <span>{{actor.system.anatomy.leftArm.armor}}/{{actor.system.anatomy.leftArm.soak}}</span>
-    </li>
-    <li class="location right-arm {{#if actor.system.anatomy.rightArm.lost}}lost{{/if}}">
-      <span>Right Arm</span>
-      <span>{{actor.system.anatomy.rightArm.armor}}/{{actor.system.anatomy.rightArm.soak}}</span>
-    </li>
-    <li class="location left-leg {{#if actor.system.anatomy.leftLeg.lost}}lost{{/if}}">
-      <span>Left Leg</span>
-      <span>{{actor.system.anatomy.leftLeg.armor}}/{{actor.system.anatomy.leftLeg.soak}}</span>
-    </li>
-    <li class="location right-leg {{#if actor.system.anatomy.rightLeg.lost}}lost{{/if}}">
-      <span>Right Leg</span>
-      <span>{{actor.system.anatomy.rightLeg.armor}}/{{actor.system.anatomy.rightLeg.soak}}</span>
-    </li>
-  </ul>
-  <h4>Conditions</h4>
-  <ul>
+{{#if actor}}
+<div class="body-container">
+  <div class="body-outline">
+    <svg viewBox="0 0 200 280" xmlns="http://www.w3.org/2000/svg">
+      <path d="M100,50 C120,50 120,60 120,70 L120,110 C120,130 110,140 100,150 C90,140 80,130 80,110 L80,70 C80,60 80,50 100,50Z" fill="#693731" />
+      <circle cx="100" cy="35" r="15" fill="#693731" />
+      <path d="M80,70 C70,75 55,90 50,110 C45,130 45,140 55,150" stroke="#693731" stroke-width="16" fill="none" />
+      <path d="M120,70 C130,75 145,90 150,110 C155,130 155,140 145,150" stroke="#693731" stroke-width="16" fill="none" />
+      <path d="M90,150 C85,170 80,190 75,230" stroke="#693731" stroke-width="15" fill="none" />
+      <path d="M110,150 C115,170 120,190 125,230" stroke="#693731" stroke-width="15" fill="none" />
+    </svg>
+  </div>
+  <div class="location-value head">
+    {{anatomy.head.armor}}/{{anatomy.head.soak}}
+    {{#if trauma.head.value}}
+    <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.head.value}}</span>
+    {{/if}}
+  </div>
+  <div class="location-value torso">
+    {{anatomy.torso.armor}}/{{anatomy.torso.soak}}
+    {{#if trauma.torso.value}}
+    <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.torso.value}}</span>
+    {{/if}}
+  </div>
+  <div class="location-value leftArm">
+    {{anatomy.leftArm.armor}}/{{anatomy.leftArm.soak}}
+    {{#if trauma.leftArm.value}}
+    <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.leftArm.value}}</span>
+    {{/if}}
+  </div>
+  <div class="location-value rightArm">
+    {{anatomy.rightArm.armor}}/{{anatomy.rightArm.soak}}
+    {{#if trauma.rightArm.value}}
+    <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.rightArm.value}}</span>
+    {{/if}}
+  </div>
+  <div class="location-value leftLeg">
+    {{anatomy.leftLeg.armor}}/{{anatomy.leftLeg.soak}}
+    {{#if trauma.leftLeg.value}}
+    <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.leftLeg.value}}</span>
+    {{/if}}
+  </div>
+  <div class="location-value rightLeg">
+    {{anatomy.rightLeg.armor}}/{{anatomy.rightLeg.soak}}
+    {{#if trauma.rightLeg.value}}
+    <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.rightLeg.value}}</span>
+    {{/if}}
+  </div>
+  <div class="conditions">
     {{#each conditions}}
-    <li>{{capitalize key}}: {{this.value}}</li>
+    <div class="condition" title="{{capitalize key}}">
+      {{#if icon}}
+      <img src="{{icon}}" alt="{{key}}" />
+      {{else}}
+      <i class="fas {{faIcon}}"></i>
+      {{/if}}
+      <span class="value">{{value}}</span>
+    </div>
     {{/each}}
-  </ul>
-  <h4>Injuries</h4>
-  <ul>
-    {{#each injuries}}
-    <li>{{name}}</li>
-    {{/each}}
-  </ul>
-  {{else}}
-  <p>No actor selected</p>
-  {{/if}}
+  </div>
 </div>
+{{/if}}


### PR DESCRIPTION
## Summary
- keep the hit location HUD in the lower left corner and give it a fixed 25% viewport size
- display condition icons as a right‑justified column and sort them alphabetically

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684108e9b788832d961bc04eb90281b9