### PR TITLE
Move HUD layout to lower left corner

### DIFF
--- a/scripts/hit-location-hud.js
+++ b/scripts/hit-location-hud.js
@@ -81,6 +81,8 @@ export class HitLocationHUD {
       }
     }
 
+    conditions.sort((a, b) => a.key.localeCompare(b.key));
+
     const data = { actor, anatomy, trauma, conditions };
     const html = await renderTemplate('systems/witch-iron/templates/hud/hit-location-hud.hbs', data);
     this.container.innerHTML = html;

--- a/styles/hit-location-hud.css
+++ b/styles/hit-location-hud.css
@@ -1,14 +1,15 @@
 /* Hit Location HUD Styles */
 #hit-location-hud {
-  position: absolute;
+  position: fixed;
   left: 10px;
-  bottom: 10px;
-  width: 260px;
-  height: 370px;
+  bottom: 260px;
+  width: 12.5vw;
+  height: 25vh;
   pointer-events: none;
   z-index: 100;
   color: #f5f3e6;
   font-family: var(--witchiron-font, serif);
+  overflow: hidden;
 }
 
 #hit-location-hud .body-container {
@@ -48,8 +49,9 @@
   top: 0;
   right: 0;
   display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   gap: 4px;
-  flex-wrap: wrap;
 }
 
 #hit-location-hud .condition {


### PR DESCRIPTION
## Summary
- place the hit location HUD on the lower left with a fixed viewport size
- list condition icons vertically in the HUD
- sort conditions alphabetically before rendering

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68410fbe3d08832db5a6bb12c540cf08