### PR TITLE
Move HUD layout to lower left corner

### DIFF
--- a/scripts/hit-location-hud.js
+++ b/scripts/hit-location-hud.js
@@ -22,7 +22,9 @@ export class HitLocationHUD {
     console.log('Witch Iron | Hit Location HUD initializing');
     this.container = document.createElement('div');
     this.container.id = 'hit-location-hud';
-    document.body.appendChild(this.container);
+    const uiLeft = document.getElementById('ui-left');
+    if (uiLeft) uiLeft.appendChild(this.container);
+    else document.body.appendChild(this.container);
 
     this.currentActor = null;
 
@@ -80,6 +82,8 @@ export class HitLocationHUD {
         });
       }
     }
+
+    conditions.sort((a, b) => a.key.localeCompare(b.key));
 
     const data = { actor, anatomy, trauma, conditions };
     const html = await renderTemplate('systems/witch-iron/templates/hud/hit-location-hud.hbs', data);

--- a/styles/hit-location-hud.css
+++ b/styles/hit-location-hud.css
@@ -2,13 +2,14 @@
 #hit-location-hud {
   position: absolute;
   left: 10px;
-  bottom: 10px;
-  width: 260px;
-  height: 370px;
+  bottom: 260px;
+  width: 12.5vw;
+  height: 25vh;
   pointer-events: none;
   z-index: 100;
   color: #f5f3e6;
   font-family: var(--witchiron-font, serif);
+  overflow: hidden;
 }
 
 #hit-location-hud .body-container {
@@ -48,8 +49,9 @@
   top: 0;
   right: 0;
   display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   gap: 4px;
-  flex-wrap: wrap;
 }
 
 #hit-location-hud .condition {


### PR DESCRIPTION
## Summary
- place the hit location HUD on the lower left with a fixed viewport size
- list condition icons vertically in the HUD
- sort conditions alphabetically before rendering
- keep HUD anchored within the left UI column

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68410fbe3d08832db5a6bb12c540cf08