### PR TITLE
Refactor hit location HUD layering

### DIFF
--- a/styles/hit-location-hud.css
+++ b/styles/hit-location-hud.css
@@ -3,8 +3,8 @@
   position: fixed;
   left: 10px;
   bottom: 260px;
-  width: 12.5vw;
-  height: 25vh;
+  width: 280px;
+  height: 370px;
   transform: scale(0.5);
   transform-origin: bottom left;
   transition: transform 0.2s ease;
@@ -25,10 +25,29 @@
   height: 100%;
 }
 
+/* generic layer used for stacking */
+#hit-location-hud .layer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+/* background silhouette layer */
+#hit-location-hud .body-outline {
+  z-index: 0;
+}
+
 #hit-location-hud .body-outline svg {
   width: 100%;
   height: 100%;
   display: block;
+}
+
+#hit-location-hud .values-layer {
+  z-index: 1;
 }
 
 #hit-location-hud .location-value {
@@ -36,6 +55,7 @@
   font-size: 0.85em;
   text-align: center;
   line-height: 1.1;
+  pointer-events: none;
 }
 
 #hit-location-hud .location-value .trauma {
@@ -51,15 +71,16 @@
 #hit-location-hud .location-value.leftLeg { top: 270px; left: 38px; }
 #hit-location-hud .location-value.rightLeg { top: 270px; left: 185px; }
 
-#hit-location-hud .conditions {
+#hit-location-hud .conditions-overlay {
   position: absolute;
   top: 0;
   right: 0;
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+  flex-direction: row;
+  align-items: flex-start;
   gap: 4px;
-  z-index: 1;
+  z-index: 2;
+  pointer-events: none;
 }
 
 #hit-location-hud .condition {

--- a/templates/hud/hit-location-hud.hbs
+++ b/templates/hud/hit-location-hud.hbs
@@ -1,6 +1,6 @@
 {{#if actor}}
 <div class="body-container">
-  <div class="body-outline">
+  <div class="layer body-outline">
     <svg viewBox="0 0 200 280" xmlns="http://www.w3.org/2000/svg">
       <path d="M100,50 C120,50 120,60 120,70 L120,110 C120,130 110,140 100,150 C90,140 80,130 80,110 L80,70 C80,60 80,50 100,50Z" fill="#693731" />
       <circle cx="100" cy="35" r="15" fill="#693731" />
@@ -10,43 +10,45 @@
       <path d="M110,150 C115,170 120,190 125,230" stroke="#693731" stroke-width="15" fill="none" />
     </svg>
   </div>
-  <div class="location-value head">
+  <div class="layer values-layer">
+    <div class="location-value head">
     {{anatomy.head.armor}}/{{anatomy.head.soak}}
     {{#if trauma.head.value}}
     <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.head.value}}</span>
     {{/if}}
-  </div>
-  <div class="location-value torso">
+    </div>
+    <div class="location-value torso">
     {{anatomy.torso.armor}}/{{anatomy.torso.soak}}
     {{#if trauma.torso.value}}
     <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.torso.value}}</span>
     {{/if}}
-  </div>
-  <div class="location-value leftArm">
+    </div>
+    <div class="location-value leftArm">
     {{anatomy.leftArm.armor}}/{{anatomy.leftArm.soak}}
     {{#if trauma.leftArm.value}}
     <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.leftArm.value}}</span>
     {{/if}}
-  </div>
-  <div class="location-value rightArm">
+    </div>
+    <div class="location-value rightArm">
     {{anatomy.rightArm.armor}}/{{anatomy.rightArm.soak}}
     {{#if trauma.rightArm.value}}
     <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.rightArm.value}}</span>
     {{/if}}
-  </div>
-  <div class="location-value leftLeg">
+    </div>
+    <div class="location-value leftLeg">
     {{anatomy.leftLeg.armor}}/{{anatomy.leftLeg.soak}}
     {{#if trauma.leftLeg.value}}
     <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.leftLeg.value}}</span>
     {{/if}}
-  </div>
-  <div class="location-value rightLeg">
+    </div>
+    <div class="location-value rightLeg">
     {{anatomy.rightLeg.armor}}/{{anatomy.rightLeg.soak}}
     {{#if trauma.rightLeg.value}}
     <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.rightLeg.value}}</span>
     {{/if}}
+    </div>
   </div>
-  <div class="conditions">
+  <div class="conditions-overlay">
     {{#each conditions}}
     <div class="condition" title="{{capitalize key}}">
       {{#if icon}}


### PR DESCRIPTION
## Summary
- use layered elements so armor/soak values and conditions render above the body silhouette
- display condition icons in a single row at the top-right

## Testing
- `pre-commit run --files styles/hit-location-hud.css templates/hud/hit-location-hud.hbs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b4ac14c0832dbee22f8c52701dd7