### PR TITLE
Rework HUD layering with grid overlay

### DIFF
--- a/styles/hit-location-hud.css
+++ b/styles/hit-location-hud.css
@@ -21,8 +21,21 @@
 
 #hit-location-hud .body-container {
   position: relative;
+  display: grid;
+  grid-template: 1fr / 1fr;
   width: 100%;
   height: 100%;
+}
+
+#hit-location-hud .layer {
+  grid-area: 1 / 1;
+  pointer-events: none;
+}
+
+#hit-location-hud .background-layer { z-index: 1; }
+#hit-location-hud .values-layer {
+  z-index: 2;
+  position: relative;
 }
 
 /* ensure the silhouette fills the container so overlays align correctly */
@@ -63,15 +76,15 @@
 #hit-location-hud .location-value.leftLeg { top: 270px; left: 38px; }
 #hit-location-hud .location-value.rightLeg { top: 270px; left: 185px; }
 
-#hit-location-hud .conditions {
-  position: absolute;
-  top: 0;
-  right: 0;
+#hit-location-hud .conditions-overlay {
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: flex-start;
   gap: 4px;
-  z-index: 1;
+  justify-self: end;
+  align-self: start;
+  z-index: 3;
   pointer-events: none;
 }
 

--- a/templates/hud/hit-location-hud.hbs
+++ b/templates/hud/hit-location-hud.hbs
@@ -1,6 +1,6 @@
 {{#if actor}}
 <div class="body-container">
-  <div class="body-outline">
+  <div class="body-outline layer background-layer">
     <svg viewBox="0 0 200 280" xmlns="http://www.w3.org/2000/svg">
       <path d="M100,50 C120,50 120,60 120,70 L120,110 C120,130 110,140 100,150 C90,140 80,130 80,110 L80,70 C80,60 80,50 100,50Z" fill="#693731" />
       <circle cx="100" cy="35" r="15" fill="#693731" />
@@ -10,43 +10,45 @@
       <path d="M110,150 C115,170 120,190 125,230" stroke="#693731" stroke-width="15" fill="none" />
     </svg>
   </div>
-  <div class="location-value head">
-    {{anatomy.head.armor}}/{{anatomy.head.soak}}
-    {{#if trauma.head.value}}
-    <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.head.value}}</span>
-    {{/if}}
+  <div class="values-layer layer">
+    <div class="location-value head">
+      {{anatomy.head.armor}}/{{anatomy.head.soak}}
+      {{#if trauma.head.value}}
+      <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.head.value}}</span>
+      {{/if}}
+    </div>
+    <div class="location-value torso">
+      {{anatomy.torso.armor}}/{{anatomy.torso.soak}}
+      {{#if trauma.torso.value}}
+      <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.torso.value}}</span>
+      {{/if}}
+    </div>
+    <div class="location-value leftArm">
+      {{anatomy.leftArm.armor}}/{{anatomy.leftArm.soak}}
+      {{#if trauma.leftArm.value}}
+      <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.leftArm.value}}</span>
+      {{/if}}
+    </div>
+    <div class="location-value rightArm">
+      {{anatomy.rightArm.armor}}/{{anatomy.rightArm.soak}}
+      {{#if trauma.rightArm.value}}
+      <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.rightArm.value}}</span>
+      {{/if}}
+    </div>
+    <div class="location-value leftLeg">
+      {{anatomy.leftLeg.armor}}/{{anatomy.leftLeg.soak}}
+      {{#if trauma.leftLeg.value}}
+      <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.leftLeg.value}}</span>
+      {{/if}}
+    </div>
+    <div class="location-value rightLeg">
+      {{anatomy.rightLeg.armor}}/{{anatomy.rightLeg.soak}}
+      {{#if trauma.rightLeg.value}}
+      <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.rightLeg.value}}</span>
+      {{/if}}
+    </div>
   </div>
-  <div class="location-value torso">
-    {{anatomy.torso.armor}}/{{anatomy.torso.soak}}
-    {{#if trauma.torso.value}}
-    <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.torso.value}}</span>
-    {{/if}}
-  </div>
-  <div class="location-value leftArm">
-    {{anatomy.leftArm.armor}}/{{anatomy.leftArm.soak}}
-    {{#if trauma.leftArm.value}}
-    <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.leftArm.value}}</span>
-    {{/if}}
-  </div>
-  <div class="location-value rightArm">
-    {{anatomy.rightArm.armor}}/{{anatomy.rightArm.soak}}
-    {{#if trauma.rightArm.value}}
-    <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.rightArm.value}}</span>
-    {{/if}}
-  </div>
-  <div class="location-value leftLeg">
-    {{anatomy.leftLeg.armor}}/{{anatomy.leftLeg.soak}}
-    {{#if trauma.leftLeg.value}}
-    <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.leftLeg.value}}</span>
-    {{/if}}
-  </div>
-  <div class="location-value rightLeg">
-    {{anatomy.rightLeg.armor}}/{{anatomy.rightLeg.soak}}
-    {{#if trauma.rightLeg.value}}
-    <span class="trauma"><i class="fas fa-biohazard"></i>{{trauma.rightLeg.value}}</span>
-    {{/if}}
-  </div>
-  <div class="conditions">
+  <div class="conditions-overlay layer">
     {{#each conditions}}
     <div class="condition" title="{{capitalize key}}">
       {{#if icon}}


### PR DESCRIPTION
## Summary
- convert hit location HUD overlay to CSS grid for reliable stacking
- position condition icons using `justify-self` and `align-self`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841b9353bc8832d9c0316398e9e9eea