### PR TITLE
Add HUD inner wrapper

### DIFF
--- a/styles/hit-location-hud.css
+++ b/styles/hit-location-hud.css
@@ -19,6 +19,12 @@
   transform: scale(1);
 }
 
+#hit-location-hud .hud-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
 #hit-location-hud .body-container {
   position: relative;
   width: 100%;

--- a/templates/hud/hit-location-hud.hbs
+++ b/templates/hud/hit-location-hud.hbs
@@ -1,5 +1,6 @@
 {{#if actor}}
-<div class="body-container">
+<div class="hud-inner">
+  <div class="body-container">
   <div class="body-outline layer background-layer">
     <svg viewBox="0 0 200 280" xmlns="http://www.w3.org/2000/svg">
       <path d="M100,50 C120,50 120,60 120,70 L120,110 C120,130 110,140 100,150 C90,140 80,130 80,110 L80,70 C80,60 80,50 100,50Z" fill="#693731" />
@@ -48,8 +49,7 @@
       {{/if}}
     </div>
   </div>
-</div>
-<div class="conditions-overlay">
+  <div class="conditions-overlay">
     {{#each conditions}}
     <div class="condition" title="{{capitalize key}}">
       {{#if icon}}
@@ -61,4 +61,5 @@
     </div>
     {{/each}}
   </div>
+</div>
 {{/if}}


### PR DESCRIPTION
## Summary
- wrap HUD template in a new `.hud-inner` element
- style `.hud-inner` to fill the HUD container

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841c52eb750832d9daa1508a25ecf68