### PR TITLE
Refine HUD wrapper structure

### DIFF
--- a/styles/hit-location-hud.css
+++ b/styles/hit-location-hud.css
@@ -4,18 +4,28 @@
   left: 10px;
   bottom: 260px;
   width: 280px;
-  height: 370px;
-  transform: scale(0.5);
-  transform-origin: bottom left;
-  transition: transform 0.2s ease;
   pointer-events: none;
   z-index: 100;
   color: #f5f3e6;
   font-family: var(--witchiron-font, serif);
+}
+
+#hit-location-hud .hud-wrapper {
+  position: relative;
+  width: 100%;
+  padding-top: 132%;
   overflow: hidden;
 }
 
-#hit-location-hud.has-conditions {
+#hit-location-hud .hud-inner {
+  position: absolute;
+  inset: 0;
+  transform: scale(0.5);
+  transform-origin: bottom left;
+  transition: transform 0.2s ease;
+}
+
+#hit-location-hud.has-conditions .hud-inner {
   transform: scale(1);
 }
 

--- a/templates/hud/hit-location-hud.hbs
+++ b/templates/hud/hit-location-hud.hbs
@@ -1,5 +1,7 @@
 {{#if actor}}
-<div class="body-container">
+<div class="hud-wrapper">
+  <div class="hud-inner">
+  <div class="body-container">
   <div class="body-outline layer background-layer">
     <svg viewBox="0 0 200 280" xmlns="http://www.w3.org/2000/svg">
       <path d="M100,50 C120,50 120,60 120,70 L120,110 C120,130 110,140 100,150 C90,140 80,130 80,110 L80,70 C80,60 80,50 100,50Z" fill="#693731" />
@@ -48,8 +50,7 @@
       {{/if}}
     </div>
   </div>
-</div>
-<div class="conditions-overlay">
+  <div class="conditions-overlay">
     {{#each conditions}}
     <div class="condition" title="{{capitalize key}}">
       {{#if icon}}
@@ -61,4 +62,6 @@
     </div>
     {{/each}}
   </div>
+</div>
+</div>
 {{/if}}


### PR DESCRIPTION
## Summary
- add `.hud-wrapper` element to maintain aspect ratio
- move scale transform to `.hud-inner` for easier layout
- adjust hit location HUD markup for new wrapper

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841c52eb750832d9daa1508a25ecf68