### PR TITLE
Switch HUD to vertical list

### DIFF
--- a/scripts/hit-location-hud.js
+++ b/scripts/hit-location-hud.js
@@ -1,15 +1,12 @@
-const CONDITION_ICONS = {
-  aflame: 'icons/svg/fire.svg',
-  bleed: 'icons/svg/blood.svg',
-  poison: 'icons/svg/poison.svg',
-  stress: 'icons/svg/burst.svg',
-  corruption: 'icons/svg/bone.svg',
-  blind: 'icons/svg/eye.svg',
-  deaf: 'icons/svg/deaf.svg',
-  pain: 'icons/svg/daze.svg'
-};
-
 const FA_ICONS = {
+  aflame: 'fa-fire',
+  bleed: 'fa-droplet',
+  poison: 'fa-skull-crossbones',
+  stress: 'fa-burst',
+  corruption: 'fa-biohazard',
+  blind: 'fa-eye-slash',
+  deaf: 'fa-ear-deaf',
+  pain: 'fa-hand-holding-medical',
   fatigue: 'fa-face-downcast-sweat',
   entangle: 'fa-link',
   helpless: 'fa-skull',
@@ -78,7 +75,6 @@ export class HitLocationHUD {
         conditions.push({
           key,
           value,
-          icon: CONDITION_ICONS[key] || null,
           faIcon: FA_ICONS[key] || 'fa-exclamation-circle'
         });
       }
@@ -89,7 +85,5 @@ export class HitLocationHUD {
     const data = { actor, anatomy, trauma, conditions };
     const html = await renderTemplate('systems/witch-iron/templates/hud/hit-location-hud.hbs', data);
     this.container.innerHTML = html;
-    if (conditions.length > 5) this.container.classList.add('big');
-    else this.container.classList.remove('big');
   }
 }

--- a/styles/hit-location-hud.css
+++ b/styles/hit-location-hud.css
@@ -10,10 +10,6 @@
   font-family: var(--witchiron-font, serif);
 }
 
-.hit-hud.big {
-  width: 30vmin;
-  max-width: 300px;
-}
 
 .hud-inner {
   width: 100%;
@@ -40,8 +36,9 @@
 .conditions-layer {
   z-index: 3;
   gap: .15rem;
-  flex-wrap: wrap;
-  align-content: flex-start;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: flex-start;
   pointer-events: auto;
 }
 

--- a/templates/hud/hit-location-hud.hbs
+++ b/templates/hud/hit-location-hud.hbs
@@ -52,11 +52,7 @@
     <div class="layer conditions-layer">
       {{#each conditions}}
       <div class="condition" title="{{capitalize key}}">
-        {{#if icon}}
-        <img src="{{icon}}" alt="{{key}}" />
-        {{else}}
         <i class="fas {{faIcon}}"></i>
-        {{/if}}
         <span class="value">{{value}}</span>
       </div>
       {{/each}}


### PR DESCRIPTION
## Summary
- display HUD conditions vertically on the right side
- keep the HUD size consistent regardless of condition count

## Testing
- `npm test` *(fails: could not read package.json)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841d66fa254832daaa78daffcf5d8f7