### PR TITLE
Add HUD tooltips for soak and conditions

### DIFF
--- a/scripts/hit-location-hud.js
+++ b/scripts/hit-location-hud.js
@@ -1,21 +1,38 @@
-const CONDITION_ICONS = {
-  aflame: 'icons/svg/fire.svg',
-  bleed: 'icons/svg/blood.svg',
-  poison: 'icons/svg/poison.svg',
-  stress: 'icons/svg/burst.svg',
-  corruption: 'icons/svg/bone.svg',
-  blind: 'icons/svg/eye.svg',
-  deaf: 'icons/svg/deaf.svg',
-  pain: 'icons/svg/daze.svg'
-};
-
 const FA_ICONS = {
+  aflame: 'fa-fire',
+  bleed: 'fa-droplet',
+  poison: 'fa-skull-crossbones',
+  stress: 'fa-burst',
+  corruption: 'fa-biohazard',
+  blind: 'fa-eye-slash',
+  deaf: 'fa-ear-deaf',
+  pain: 'fa-hand-holding-medical',
   fatigue: 'fa-face-downcast-sweat',
   entangle: 'fa-link',
   helpless: 'fa-skull',
   stun: 'fa-bolt',
   prone: 'fa-person-falling'
 };
+
+const CONDITION_INFO = {
+  aflame: { name: 'Aflame', effect: 'Smoldering Flesh. Roll d6 each round, on <= rating make a Hardship Quarrel vs rating to remove all Aflame, Bleed or Poison or die.' },
+  bleed: { name: 'Bleed', effect: 'Deep Gashes. Roll d6 each round, on <= rating make a Hardship Quarrel vs rating to remove all Aflame, Bleed or Poison or die.' },
+  poison: { name: 'Poison', effect: 'Vile Toxins. Roll d6 each round, on <= rating make a Hardship Quarrel vs rating to remove all Aflame, Bleed or Poison or die.' },
+  stress: { name: 'Stress', effect: 'Profane Thoughts. On three stacks make a Hardship or Steel Quarrel vs rating or become changed.' },
+  corruption: { name: 'Corruption', effect: 'Traitorous Flesh. On three stacks make a Hardship or Steel Quarrel vs rating or become changed.' },
+  blind: { name: 'Blind', effect: 'Retina Overload. -(rating*10)% to sight-based checks. Reduces by one each hour.' },
+  deaf: { name: 'Deaf', effect: 'Ringing in Ears. -(rating*10)% to hearing and speech checks. Reduces by one each hour.' },
+  pain: { name: 'Pain', effect: 'Agony. -(rating*10)% to all checks. Reduces by one each hour.' },
+  fatigue: { name: 'Fatigue', effect: 'Muscle Exhaustion. Occupies Encumbrance slots; removed by rest if not from a lingering quarrel.' },
+  entangle: { name: 'Entangle', effect: 'Restricts movement. Reduces by one each round or slip out.' },
+  helpless: { name: 'Helpless', effect: 'Prevents actions and movement. Opponents can inflict any injury while in melee.' },
+  stun: { name: 'Stun', effect: 'Prevents actions. Reduced by smelling salts.' },
+  prone: { name: 'Prone', effect: '-20% to checks and enemies gain +20%. Spend an action to stand.' }
+};
+
+function capitalize(str) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
 
 export class HitLocationHUD {
   static init() {
@@ -75,21 +92,31 @@ export class HitLocationHUD {
       if (key === 'trauma') continue;
       const value = Number(data?.value || 0);
       if (value >= 1) {
+        const info = CONDITION_INFO[key] || { name: capitalize(key), effect: '' };
         conditions.push({
           key,
           value,
-          icon: CONDITION_ICONS[key] || null,
-          faIcon: FA_ICONS[key] || 'fa-exclamation-circle'
+          faIcon: FA_ICONS[key] || 'fa-exclamation-circle',
+          tooltip: `${info.name} (${value}) - ${info.effect}`
         });
       }
     }
 
     conditions.sort((a, b) => a.key.localeCompare(b.key));
 
-    const data = { actor, anatomy, trauma, conditions };
+    const soakTooltips = {};
+    const rb = actor.system?.attributes?.robustness?.bonus || 0;
+    const wear = actor.system?.battleWear?.armor?.value || 0;
+    for (const loc of ['head','torso','leftArm','rightArm','leftLeg','rightLeg']) {
+      const part = anatomy[loc] || {};
+      const soak = Number(part.soak || 0);
+      const av = Number(part.armor || 0);
+      const other = soak - rb - (av - wear);
+      soakTooltips[loc] = `Soak = ${rb} + ${other} + (${av} - ${wear}) = ${soak}`;
+    }
+
+    const data = { actor, anatomy, trauma, conditions, soakTooltips };
     const html = await renderTemplate('systems/witch-iron/templates/hud/hit-location-hud.hbs', data);
     this.container.innerHTML = html;
-    if (conditions.length > 5) this.container.classList.add('big');
-    else this.container.classList.remove('big');
   }
 }

--- a/styles/hit-location-hud.css
+++ b/styles/hit-location-hud.css
@@ -10,10 +10,6 @@
   font-family: var(--witchiron-font, serif);
 }
 
-.hit-hud.big {
-  width: 30vmin;
-  max-width: 300px;
-}
 
 .hud-inner {
   width: 100%;
@@ -40,8 +36,9 @@
 .conditions-layer {
   z-index: 3;
   gap: .15rem;
-  flex-wrap: wrap;
-  align-content: flex-start;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: flex-start;
   pointer-events: auto;
 }
 

--- a/templates/hud/hit-location-hud.hbs
+++ b/templates/hud/hit-location-hud.hbs
@@ -12,37 +12,37 @@
       </svg>
     </div>
     <div class="layer values-layer">
-      <div class="location-value head">
+      <div class="location-value head" title="{{soakTooltips.head}}">
         {{anatomy.head.soak}}({{anatomy.head.armor}})
         {{#if trauma.head.value}}
         <span class="trauma"><i class="fa-solid fa-bone-break"></i> {{trauma.head.value}}</span>
         {{/if}}
       </div>
-    <div class="location-value torso">
+    <div class="location-value torso" title="{{soakTooltips.torso}}">
       {{anatomy.torso.soak}}({{anatomy.torso.armor}})
       {{#if trauma.torso.value}}
       <span class="trauma"><i class="fa-solid fa-bone-break"></i> {{trauma.torso.value}}</span>
       {{/if}}
     </div>
-    <div class="location-value leftArm">
+    <div class="location-value leftArm" title="{{soakTooltips.leftArm}}">
       {{anatomy.leftArm.soak}}({{anatomy.leftArm.armor}})
       {{#if trauma.leftArm.value}}
       <span class="trauma"><i class="fa-solid fa-bone-break"></i> {{trauma.leftArm.value}}</span>
       {{/if}}
     </div>
-    <div class="location-value rightArm">
+    <div class="location-value rightArm" title="{{soakTooltips.rightArm}}">
       {{anatomy.rightArm.soak}}({{anatomy.rightArm.armor}})
       {{#if trauma.rightArm.value}}
       <span class="trauma"><i class="fa-solid fa-bone-break"></i> {{trauma.rightArm.value}}</span>
       {{/if}}
     </div>
-    <div class="location-value leftLeg">
+    <div class="location-value leftLeg" title="{{soakTooltips.leftLeg}}">
       {{anatomy.leftLeg.soak}}({{anatomy.leftLeg.armor}})
       {{#if trauma.leftLeg.value}}
       <span class="trauma"><i class="fa-solid fa-bone-break"></i> {{trauma.leftLeg.value}}</span>
       {{/if}}
       </div>
-      <div class="location-value rightLeg">
+      <div class="location-value rightLeg" title="{{soakTooltips.rightLeg}}">
         {{anatomy.rightLeg.soak}}({{anatomy.rightLeg.armor}})
         {{#if trauma.rightLeg.value}}
         <span class="trauma"><i class="fa-solid fa-bone-break"></i> {{trauma.rightLeg.value}}</span>
@@ -51,12 +51,8 @@
     </div>
     <div class="layer conditions-layer">
       {{#each conditions}}
-      <div class="condition" title="{{capitalize key}}">
-        {{#if icon}}
-        <img src="{{icon}}" alt="{{key}}" />
-        {{else}}
+      <div class="condition" title="{{tooltip}}">
         <i class="fas {{faIcon}}"></i>
-        {{/if}}
         <span class="value">{{value}}</span>
       </div>
       {{/each}}


### PR DESCRIPTION
## Summary
- add detailed condition data and show tooltip for each condition
- compute per-location soak math and show formula on hover

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841d66fa254832daaa78daffcf5d8f7