### PR TITLE
Enhance HUD tooltips

### DIFF
--- a/scripts/hit-location-hud.js
+++ b/scripts/hit-location-hud.js
@@ -14,6 +14,63 @@ const FA_ICONS = {
   prone: 'fa-person-falling'
 };
 
+// Descriptive info for each condition including a function to
+// generate the tooltip text based on its rating
+const CONDITION_INFO = {
+  aflame: {
+    name: 'Aflame',
+    effect: r => `Roll 1d6 each round. On ≤ ${r}, Hardship Quarrel vs ${r} or die.`
+  },
+  bleed: {
+    name: 'Bleed',
+    effect: r => `Roll 1d6 each round. On ≤ ${r}, Hardship Quarrel vs ${r} or die.`
+  },
+  poison: {
+    name: 'Poison',
+    effect: r => `Roll 1d6 each round. On ≤ ${r}, Hardship Quarrel vs ${r} or die.`
+  },
+  blind: {
+    name: 'Blind',
+    effect: r => `${r * 10}% penalty to sight checks (reduce 1/hour).`
+  },
+  deaf: {
+    name: 'Deaf',
+    effect: r => `${r * 10}% penalty to hearing & speech checks (reduce 1/hour).`
+  },
+  pain: {
+    name: 'Pain',
+    effect: r => `${r * 10}% penalty to all checks (reduce 1/hour).`
+  },
+  stress: {
+    name: 'Stress',
+    effect: r => `Every 3 stacks: Steel quarrel vs ${r} or gain Madness.`
+  },
+  corruption: {
+    name: 'Corruption',
+    effect: r => `Every 3 stacks: Steel quarrel vs ${r} or gain Mutation.`
+  },
+  fatigue: {
+    name: 'Fatigue',
+    effect: () => 'Takes up Encumbrance; removed by rest.'
+  },
+  entangle: {
+    name: 'Entangle',
+    effect: () => 'Prevents movement. Reduce 1 each round.'
+  },
+  helpless: {
+    name: 'Helpless',
+    effect: () => 'Prevents actions & movement; foes may inflict any Injury. Reduce 1/round.'
+  },
+  stun: {
+    name: 'Stun',
+    effect: () => 'Prevents actions. Reduce 1 each round.'
+  },
+  prone: {
+    name: 'Prone',
+    effect: () => '-20% to checks; foes +20% until you stand.'
+  }
+};
+
 export class HitLocationHUD {
   static init() {
     console.log('Witch Iron | Hit Location HUD initializing');
@@ -66,23 +123,51 @@ export class HitLocationHUD {
     const anatomy = actor.system?.anatomy || {};
     const trauma = actor.system?.conditions?.trauma || {};
 
+    // Calculate per-location soak tooltip text
+    const rb = Number(actor.system?.attributes?.robustness?.bonus || 0);
+    const wear = Number(actor.system?.battleWear?.armor?.value || 0);
+    const soakTooltips = {};
+    for (const loc of ["head","torso","leftArm","rightArm","leftLeg","rightLeg"]) {
+      const locData = anatomy[loc] || {};
+      const soak = Number(locData.soak || 0);
+      const av = Number(locData.armor || 0);
+      const other = soak - rb - (av - wear);
+      const otherVal = other > 0 ? other : 0;
+      soakTooltips[loc] = `${rb} + ${otherVal} + (${av} - ${wear}) = ${soak}`;
+    }
+
     const condObj = actor.system?.conditions || {};
     const conditions = [];
     for (const [key, data] of Object.entries(condObj)) {
       if (key === 'trauma') continue;
       const value = Number(data?.value || 0);
       if (value >= 1) {
+        const info = CONDITION_INFO[key];
+        const name = info?.name || key.charAt(0).toUpperCase() + key.slice(1);
+        const effect = info?.effect ? info.effect(value) : '';
+        const tooltip = `${name} ${value}${effect ? `: ${effect}` : ''}`;
         conditions.push({
           key,
           value,
-          faIcon: FA_ICONS[key] || 'fa-exclamation-circle'
+          faIcon: FA_ICONS[key] || 'fa-exclamation-circle',
+          tooltip
         });
       }
     }
 
     conditions.sort((a, b) => a.key.localeCompare(b.key));
 
-    const data = { actor, anatomy, trauma, conditions };
+    // Trauma tooltip text per location
+    const traumaTooltips = {};
+    for (const loc of Object.keys(trauma)) {
+      const rating = Number(trauma[loc]?.value || 0);
+      if (rating > 0) {
+        const locLabel = loc.replace(/([A-Z])/g, ' $1').replace(/^./, c => c.toUpperCase());
+        traumaTooltips[loc] = `Trauma (${locLabel}) ${rating}: ${rating * 20}% penalty to checks involving ${locLabel}.`;
+      }
+    }
+
+    const data = { actor, anatomy, trauma, conditions, soakTooltips, traumaTooltips };
     const html = await renderTemplate('systems/witch-iron/templates/hud/hit-location-hud.hbs', data);
     this.container.innerHTML = html;
   }

--- a/templates/hud/hit-location-hud.hbs
+++ b/templates/hud/hit-location-hud.hbs
@@ -12,46 +12,46 @@
       </svg>
     </div>
     <div class="layer values-layer">
-      <div class="location-value head">
+      <div class="location-value head" title="{{soakTooltips.head}}">
         {{anatomy.head.soak}}({{anatomy.head.armor}})
         {{#if trauma.head.value}}
-        <span class="trauma"><i class="fa-solid fa-bone-break"></i> {{trauma.head.value}}</span>
+        <span class="trauma" title="{{traumaTooltips.head}}"><i class="fa-solid fa-bone-break"></i> {{trauma.head.value}}</span>
         {{/if}}
       </div>
-    <div class="location-value torso">
+    <div class="location-value torso" title="{{soakTooltips.torso}}">
       {{anatomy.torso.soak}}({{anatomy.torso.armor}})
       {{#if trauma.torso.value}}
-      <span class="trauma"><i class="fa-solid fa-bone-break"></i> {{trauma.torso.value}}</span>
+      <span class="trauma" title="{{traumaTooltips.torso}}"><i class="fa-solid fa-bone-break"></i> {{trauma.torso.value}}</span>
       {{/if}}
     </div>
-    <div class="location-value leftArm">
+    <div class="location-value leftArm" title="{{soakTooltips.leftArm}}">
       {{anatomy.leftArm.soak}}({{anatomy.leftArm.armor}})
       {{#if trauma.leftArm.value}}
-      <span class="trauma"><i class="fa-solid fa-bone-break"></i> {{trauma.leftArm.value}}</span>
+      <span class="trauma" title="{{traumaTooltips.leftArm}}"><i class="fa-solid fa-bone-break"></i> {{trauma.leftArm.value}}</span>
       {{/if}}
     </div>
-    <div class="location-value rightArm">
+    <div class="location-value rightArm" title="{{soakTooltips.rightArm}}">
       {{anatomy.rightArm.soak}}({{anatomy.rightArm.armor}})
       {{#if trauma.rightArm.value}}
-      <span class="trauma"><i class="fa-solid fa-bone-break"></i> {{trauma.rightArm.value}}</span>
+      <span class="trauma" title="{{traumaTooltips.rightArm}}"><i class="fa-solid fa-bone-break"></i> {{trauma.rightArm.value}}</span>
       {{/if}}
     </div>
-    <div class="location-value leftLeg">
+    <div class="location-value leftLeg" title="{{soakTooltips.leftLeg}}">
       {{anatomy.leftLeg.soak}}({{anatomy.leftLeg.armor}})
       {{#if trauma.leftLeg.value}}
-      <span class="trauma"><i class="fa-solid fa-bone-break"></i> {{trauma.leftLeg.value}}</span>
+      <span class="trauma" title="{{traumaTooltips.leftLeg}}"><i class="fa-solid fa-bone-break"></i> {{trauma.leftLeg.value}}</span>
       {{/if}}
       </div>
-      <div class="location-value rightLeg">
+      <div class="location-value rightLeg" title="{{soakTooltips.rightLeg}}">
         {{anatomy.rightLeg.soak}}({{anatomy.rightLeg.armor}})
         {{#if trauma.rightLeg.value}}
-        <span class="trauma"><i class="fa-solid fa-bone-break"></i> {{trauma.rightLeg.value}}</span>
+        <span class="trauma" title="{{traumaTooltips.rightLeg}}"><i class="fa-solid fa-bone-break"></i> {{trauma.rightLeg.value}}</span>
         {{/if}}
       </div>
     </div>
     <div class="layer conditions-layer">
       {{#each conditions}}
-      <div class="condition" title="{{capitalize key}}">
+      <div class="condition" title="{{tooltip}}">
         <i class="fas {{faIcon}}"></i>
         <span class="value">{{value}}</span>
       </div>


### PR DESCRIPTION
## Summary
- add condition info map and tooltip generation in hit-location-hud script
- calculate per-location soak formula tooltips
- display new tooltip text for soak values, trauma and conditions

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6841dcbeebf0832d9fdd979ecfa84b50