### PR TITLE
Support per-location armor wear

### DIFF
--- a/scripts/hit-location-hud.js
+++ b/scripts/hit-location-hud.js
@@ -125,15 +125,17 @@ export class HitLocationHUD {
 
     // Calculate per-location soak tooltip text
     const rb = Number(actor.system?.attributes?.robustness?.bonus || 0);
-    const wear = Number(actor.system?.battleWear?.armor?.value || 0);
+    const wear = {};
     const soakTooltips = {};
-    for (const loc of ["head","torso","leftArm","rightArm","leftLeg","rightLeg"]) {
+    const LOCS = ["head","torso","leftArm","rightArm","leftLeg","rightLeg"];
+    for (const loc of LOCS) {
+      wear[loc] = Number(actor.system?.battleWear?.armor?.[loc]?.value || 0);
       const locData = anatomy[loc] || {};
       const soak = Number(locData.soak || 0);
       const av = Number(locData.armor || 0);
-      const other = soak - rb - (av - wear);
+      const other = soak - rb - (av - wear[loc]);
       const otherVal = other > 0 ? other : 0;
-      soakTooltips[loc] = `${rb} + ${otherVal} + (${av} - ${wear}) = ${soak}`;
+      soakTooltips[loc] = `${rb} + ${otherVal} + (${av} - ${wear[loc]}) = ${soak}`;
     }
 
     const condObj = actor.system?.conditions || {};

--- a/templates/actors/monster-sheet.hbs
+++ b/templates/actors/monster-sheet.hbs
@@ -151,11 +151,49 @@
               
               <div class="form-group battle-wear-controls">
                 <label>Armor Battle Wear (Max: {{system.derived.armorBonusMax}})</label>
-                <div class="battle-wear-control">
-                  <button type="button" class="battle-wear-minus" data-type="armor"><i class="fas fa-minus"></i></button>
-                  <span class="battle-wear-value" data-type="armor">{{system.battleWear.armor.value}}</span>
-                  <button type="button" class="battle-wear-plus" data-type="armor"><i class="fas fa-plus"></i></button>
-                  <button type="button" class="battle-wear-reset" data-type="armor"><i class="fas fa-undo"></i></button>
+                <div class="grid grid-2col">
+                  <div class="battle-wear-control">
+                    <span class="location-label">Head</span>
+                    <button type="button" class="battle-wear-minus" data-type="armor-head"><i class="fas fa-minus"></i></button>
+                    <span class="battle-wear-value" data-type="armor-head">{{system.battleWear.armor.head.value}}</span>
+                    <button type="button" class="battle-wear-plus" data-type="armor-head"><i class="fas fa-plus"></i></button>
+                    <button type="button" class="battle-wear-reset" data-type="armor-head"><i class="fas fa-undo"></i></button>
+                  </div>
+                  <div class="battle-wear-control">
+                    <span class="location-label">Torso</span>
+                    <button type="button" class="battle-wear-minus" data-type="armor-torso"><i class="fas fa-minus"></i></button>
+                    <span class="battle-wear-value" data-type="armor-torso">{{system.battleWear.armor.torso.value}}</span>
+                    <button type="button" class="battle-wear-plus" data-type="armor-torso"><i class="fas fa-plus"></i></button>
+                    <button type="button" class="battle-wear-reset" data-type="armor-torso"><i class="fas fa-undo"></i></button>
+                  </div>
+                  <div class="battle-wear-control">
+                    <span class="location-label">Left Arm</span>
+                    <button type="button" class="battle-wear-minus" data-type="armor-leftArm"><i class="fas fa-minus"></i></button>
+                    <span class="battle-wear-value" data-type="armor-leftArm">{{system.battleWear.armor.leftArm.value}}</span>
+                    <button type="button" class="battle-wear-plus" data-type="armor-leftArm"><i class="fas fa-plus"></i></button>
+                    <button type="button" class="battle-wear-reset" data-type="armor-leftArm"><i class="fas fa-undo"></i></button>
+                  </div>
+                  <div class="battle-wear-control">
+                    <span class="location-label">Right Arm</span>
+                    <button type="button" class="battle-wear-minus" data-type="armor-rightArm"><i class="fas fa-minus"></i></button>
+                    <span class="battle-wear-value" data-type="armor-rightArm">{{system.battleWear.armor.rightArm.value}}</span>
+                    <button type="button" class="battle-wear-plus" data-type="armor-rightArm"><i class="fas fa-plus"></i></button>
+                    <button type="button" class="battle-wear-reset" data-type="armor-rightArm"><i class="fas fa-undo"></i></button>
+                  </div>
+                  <div class="battle-wear-control">
+                    <span class="location-label">Left Leg</span>
+                    <button type="button" class="battle-wear-minus" data-type="armor-leftLeg"><i class="fas fa-minus"></i></button>
+                    <span class="battle-wear-value" data-type="armor-leftLeg">{{system.battleWear.armor.leftLeg.value}}</span>
+                    <button type="button" class="battle-wear-plus" data-type="armor-leftLeg"><i class="fas fa-plus"></i></button>
+                    <button type="button" class="battle-wear-reset" data-type="armor-leftLeg"><i class="fas fa-undo"></i></button>
+                  </div>
+                  <div class="battle-wear-control">
+                    <span class="location-label">Right Leg</span>
+                    <button type="button" class="battle-wear-minus" data-type="armor-rightLeg"><i class="fas fa-minus"></i></button>
+                    <span class="battle-wear-value" data-type="armor-rightLeg">{{system.battleWear.armor.rightLeg.value}}</span>
+                    <button type="button" class="battle-wear-plus" data-type="armor-rightLeg"><i class="fas fa-plus"></i></button>
+                    <button type="button" class="battle-wear-reset" data-type="armor-rightLeg"><i class="fas fa-undo"></i></button>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- restructure monster battle wear to track wear per hit location
- show new armor wear controls on the monster sheet
- account for location wear in derived stats and hit‑location workflows
- update HUD soak tooltips
- fix undefined `locKey` in battle wear tracking

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841e61b50a8832d84055aed6413110b