### PR TITLE
Fix battle wear handling and armor bonus lookup

### DIFF
--- a/scripts/hit-location.js
+++ b/scripts/hit-location.js
@@ -474,7 +474,12 @@ export class HitLocationSelector {
         if (game.witch) game.witch.currentInjury = {};
         
         // Get battle wear data AND actor references from attacker and defender
-        const returnData = await this._getBattleWearData(combatData.attacker, combatData.defender, combatData.location.toLowerCase());
+        const normalizedLocation = combatData.location.toLowerCase().replace(/\s+/g, "-");
+        const returnData = await this._getBattleWearData(
+            combatData.attacker,
+            combatData.defender,
+            normalizedLocation
+        );
         const battleWearDataForTemplate = { attacker: returnData.attacker, defender: returnData.defender }; // Separate for template clarity
         const attackerActor = returnData.actors.attacker; // Use actor from _getBattleWearData
         const defenderActor = returnData.actors.defender; // Use actor from _getBattleWearData
@@ -497,8 +502,10 @@ export class HitLocationSelector {
         
         if (defenderActor) {
             defenderAbilityBonus = defenderActor.system?.derived?.abilityBonus || 3;
-            armorBonus = defenderActor.system?.derived?.armorBonusEffective || 0; 
-            armorBonusMax = defenderActor.system?.derived?.armorBonusMax || 0; 
+            const locMap = { head:'head', torso:'torso', 'left-arm':'leftArm', 'right-arm':'rightArm', 'left-leg':'leftLeg', 'right-leg':'rightLeg' };
+            const locKey = locMap[normalizedLocation] || normalizedLocation;
+            armorBonus = defenderActor.system?.derived?.armorBonusEffective?.[locKey] || 0;
+            armorBonusMax = defenderActor.system?.derived?.armorBonusMax || 0;
             console.log(`Defender ${combatData.defender} - Ability: ${defenderAbilityBonus}, Effective Armor: ${armorBonus}, Max Armor: ${armorBonusMax}`);
         }
         
@@ -710,7 +717,8 @@ export class HitLocationSelector {
         
         // Default battle wear data object also holds actor refs
         const locMap = { head: 'head', torso: 'torso', 'left-arm': 'leftArm', 'right-arm': 'rightArm', 'left-leg': 'leftLeg', 'right-leg': 'rightLeg' };
-        const locKey = locMap[location] || location;
+        const normalizedLocation = String(location).toLowerCase().replace(/\s+/g, '-');
+        const locKey = locMap[normalizedLocation] || normalizedLocation;
 
         const returnData = {
             actors: {
@@ -1154,7 +1162,8 @@ async function applyBattleWear(message, attackerWearToAdd, defenderWearToAdd, lo
         attackerWearToAdd = Math.max(0, parseInt(attackerWearToAdd) || 0);
         defenderWearToAdd = Math.max(0, parseInt(defenderWearToAdd) || 0);
 
-        // Normalize the location string to the actor data key used for armor
+        // Normalize the location string to match actor data keys
+        // e.g. "left arm" -> "leftArm"
         const locMap = {
             head: "head",
             torso: "torso",
@@ -1163,7 +1172,8 @@ async function applyBattleWear(message, attackerWearToAdd, defenderWearToAdd, lo
             "left-leg": "leftLeg",
             "right-leg": "rightLeg"
         };
-        const locKey = locMap[location] || location;
+        const normalizedLocation = String(location).toLowerCase().replace(/\s+/g, "-");
+        const locKey = locMap[normalizedLocation] || normalizedLocation;
 
         // If both wear values are 0, nothing to add
         if (attackerWearToAdd === 0 && defenderWearToAdd === 0) {
@@ -2597,10 +2607,10 @@ function attachInjuryMessageHandlers(messageId) {
                     
                     try {
                         if (game.user.isGM) {
-                            // GM users can update directly
-                            console.log("User is GM - updating battle wear directly");
-                            
-                            // Update message flags and actors
+                            // GM users can update message flags directly
+                            console.log("User is GM - recording battle wear selection");
+
+                            // Update message flags with the selected values
                             const locEl = messageElement.querySelector('.injury-row');
                             const loc = locEl?.dataset.location?.toLowerCase() || 'torso';
                             await message.update({
@@ -2611,8 +2621,6 @@ function attachInjuryMessageHandlers(messageId) {
                                 }
                             });
 
-                            await updateActorBattleWear(message, currentAttackerWear, currentDefenderWear, loc);
-                            
                             // Broadcast to all clients that the update is complete
                             game.socket.emit("system.witch-iron.battleWearUpdate", {
                                 messageId: message.id,
@@ -3048,7 +3056,8 @@ async function updateActorBattleWear(message, attackerWear, defenderWear, locati
     // Update defender
     if (defenderActor) {
         const locMap = { head:'head', torso:'torso', 'left-arm':'leftArm', 'right-arm':'rightArm', 'left-leg':'leftLeg', 'right-leg':'rightLeg' };
-        const locKey = locMap[location] || location;
+        const normalizedLocation = String(location).toLowerCase().replace(/\s+/g, '-');
+        const locKey = locMap[normalizedLocation] || normalizedLocation;
         console.log(`Updating ${defenderName}'s armor battle wear to ${defenderWear} at ${locKey}`);
         
         // Ensure the system is initialized


### PR DESCRIPTION
## Summary
- sanitize combat location and use it when fetching armor bonuses
- stop applying battle wear when adjusting values so final update isn't doubled

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/witch-iron/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6841ee89f478832da4809116928ef3e6