### PR TITLE
Add defender token display and damage preview

### DIFF
--- a/scripts/hit-location.js
+++ b/scripts/hit-location.js
@@ -172,34 +172,51 @@ export class HitLocationSelector {
         console.log(`Opening dialog with ${netHits} net hits`);
         
         // Create dialog data
-            const dialogData = {
+        const dialogData = {
             attacker: data.attacker,
             defender: data.defender,
-                damageAmount: data.damage || 0,
+            damageAmount: data.damage || 0,
             defenderName: data.defender || "Target",
             netHits: netHits,
             remainingHits: netHits,
-                autoApply: true,
+            autoApply: true,
             combatId: data.combatId,
-                applyHitCallback: (location, remainingHits) => {
-                    // Apply the hit with the selected location and remaining hits
+            weaponDamage: data.weaponDmg || 0,
+            soakValues: {},
+            defenderImg: "icons/svg/mystery-man.svg",
+            applyHitCallback: (location, remainingHits) => {
                 this._applyHit(
-                    data.attacker, 
-                    data.defender, 
-                    data.damage, 
-                    location, 
-                    data.messageId, 
-                    remainingHits, 
+                    data.attacker,
+                    data.defender,
+                    data.damage,
+                    location,
+                    data.messageId,
+                    remainingHits,
                     data.combatId,
-                    data.weaponDmg || 0,  // Pass weapon damage
-                    data.soak || 0        // Pass soak
+                    data.weaponDmg || 0,
+                    data.soak || 0
                 );
             }
         };
         
         // Get battle wear data if we have attacker and defender names
         if (data.attacker && data.defender) {
-            dialogData.battleWear = await this._getBattleWearData(data.attacker, data.defender, 'torso');
+            const bwData = await this._getBattleWearData(data.attacker, data.defender, 'torso');
+            dialogData.battleWear = { attacker: bwData.attacker, defender: bwData.defender };
+
+            const defActor = bwData.actors.defender;
+            if (defActor) {
+                dialogData.defenderImg = bwData.defender.tokenImg;
+                const anat = defActor.system?.anatomy || {};
+                dialogData.soakValues = {
+                    head: Number(anat.head?.soak || 0),
+                    torso: Number(anat.torso?.soak || 0),
+                    'left-arm': Number(anat.leftArm?.soak || 0),
+                    'right-arm': Number(anat.rightArm?.soak || 0),
+                    'left-leg': Number(anat.leftLeg?.soak || 0),
+                    'right-leg': Number(anat.rightLeg?.soak || 0)
+                };
+            }
         }
         
         // Create and render a new dialog
@@ -1483,6 +1500,9 @@ export class HitLocationDialog extends Application {
         // Ensure netHits is properly parsed as a number
         this.netHits = parseInt(data.netHits) || 0;
         this.remainingHits = this.netHits;
+        this.weaponDamage = data.weaponDamage || 0;
+        this.soakValues = data.soakValues || {};
+        this.defenderImg = data.defenderImg || "icons/svg/mystery-man.svg";
         
         console.log(`HitLocationDialog initialized with netHits: ${this.netHits}, remaining: ${this.remainingHits}`);
         
@@ -1517,10 +1537,15 @@ export class HitLocationDialog extends Application {
     
     /** @override */
     getData(options={}) {
+        const defaultLoc = 'torso';
+        const soak = this.soakValues[defaultLoc] || 0;
         return {
             defenderName: this.data.defenderName || "Target",
+            defenderImg: this.defenderImg,
             damageAmount: this.data.damageAmount || 0,
-            netHits: this.netHits
+            netHits: this.netHits,
+            damagePreview: this.weaponDamage + this.netHits,
+            currentSoak: soak
         };
     }
 
@@ -1564,6 +1589,9 @@ export class HitLocationDialog extends Application {
         
         // Update available move buttons
         this.updateAvailableMoves();
+
+        // Update damage preview and soak display
+        this.updateDamagePreview();
     }
     
     /**
@@ -1588,6 +1616,8 @@ export class HitLocationDialog extends Application {
         selectedPart.addClass('selected');
         
         this.selectedLocation = location;
+
+        this.updateDamagePreview();
         
         // Format the location name for display
         const displayLocation = this.formatLocationName(location);
@@ -1668,9 +1698,11 @@ export class HitLocationDialog extends Application {
         // Update remaining hits
         this.remainingHits -= this.moveCost;
         this.element.find('#net-hits-remaining').text(this.remainingHits);
-        
+
         // Select the new location
         this.selectLocationInAttackerPhase(targetLocation);
+
+        this.updateDamagePreview();
     }
     
     /**
@@ -1695,11 +1727,13 @@ export class HitLocationDialog extends Application {
         
         // Update the selected location
         this.selectedLocation = location;
-        
+
         // Update display
         const displayLocation = this.formatLocationName(location);
         this.element.find('#selected-location').text(displayLocation);
-        
+
+        this.updateDamagePreview();
+
         // Update available moves
         this.updateAvailableMoves();
     }
@@ -1716,9 +1750,11 @@ export class HitLocationDialog extends Application {
         // Refund the net hits
         this.remainingHits += this.moveCost;
         this.element.find('#net-hits-remaining').text(this.remainingHits);
-        
+
         // Select the previous location
         this.selectLocationInAttackerPhase(previousLocation);
+
+        this.updateDamagePreview();
     }
     
     /**
@@ -1727,9 +1763,20 @@ export class HitLocationDialog extends Application {
      * @returns {string} The formatted location name
      */
     formatLocationName(location) {
-        return location.split('-').map(word => 
+        return location.split('-').map(word =>
             word.charAt(0).toUpperCase() + word.slice(1)
         ).join(' ');
+    }
+
+    /**
+     * Update damage preview and soak text based on current state
+     */
+    updateDamagePreview() {
+        const loc = this.selectedLocation || 'torso';
+        const soak = this.soakValues[loc] || 0;
+        const damage = this.weaponDamage + this.remainingHits;
+        this.element.find('#damage-preview').text(damage);
+        this.element.find('#location-soak').text(soak);
     }
     
     /**
@@ -1757,8 +1804,10 @@ export class HitLocationDialog extends Application {
     /** @override */
     activateListeners(html) {
         super.activateListeners(html);
-        
+
         console.log("Activating listeners for hit location dialog");
+
+        this.updateDamagePreview();
         
         // Location labels for defender phase
         const locationLabels = html.find('.location-label');

--- a/styles/hit-location.css
+++ b/styles/hit-location.css
@@ -6,6 +6,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+    position: relative;
 }
 
 .hit-location-selector h2 {
@@ -214,4 +215,27 @@
 
 .random-location-btn:hover, .confirm-location-btn:hover {
     background: rgba(143, 55, 48, 0.9) !important;
-} 
+}
+
+.defender-info {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    text-align: center;
+}
+
+.defender-info img {
+    width: 50px;
+    height: 50px;
+    border: 1px solid #000;
+}
+
+.defender-info .defender-name {
+    font-size: 0.8em;
+}
+
+.damage-preview, .soak-display {
+    font-size: 0.9em;
+    color: #000;
+    margin-top: 3px;
+}

--- a/templates/dialogs/hit-location-selector.hbs
+++ b/templates/dialogs/hit-location-selector.hbs
@@ -1,5 +1,9 @@
 <div class="hit-location-selector">
     <h2>Select Hit Location</h2>
+    <div class="defender-info">
+        <img src="{{defenderImg}}" alt="{{defenderName}}">
+        <div class="defender-name">{{defenderName}}</div>
+    </div>
     
     <div class="hit-location-phase defender-phase">
         <div class="compact-info" style="color: #000;">
@@ -19,6 +23,8 @@
                 <p>Net Hits: <strong id="net-hits-remaining">{{netHits}}</strong></p>
                 <button class="undo-move-btn" disabled>Undo Last Move</button>
             </div>
+            <div class="damage-preview">Damage: <strong id="damage-preview">{{damagePreview}}</strong></div>
+            <div class="soak-display">Soak: <strong id="location-soak">{{currentSoak}}</strong></div>
         </div>
     </div>
     


### PR DESCRIPTION
## Summary
- show the defender token image and name on hit location dialogs
- pull soak values from the actor's anatomy
- preview damage during attacker phase while spending net hits
- style new elements in hit location selector

## Testing
- `node --check scripts/hit-location.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841f62a537c832d824fedf34caeaa3f