### PR TITLE
Add limb soak display and token positioning

### DIFF
--- a/scripts/hit-location.js
+++ b/scripts/hit-location.js
@@ -172,34 +172,59 @@ export class HitLocationSelector {
         console.log(`Opening dialog with ${netHits} net hits`);
         
         // Create dialog data
-            const dialogData = {
+        const dialogData = {
             attacker: data.attacker,
             defender: data.defender,
-                damageAmount: data.damage || 0,
+            damageAmount: data.damage || 0,
             defenderName: data.defender || "Target",
             netHits: netHits,
             remainingHits: netHits,
-                autoApply: true,
+            autoApply: true,
             combatId: data.combatId,
-                applyHitCallback: (location, remainingHits) => {
-                    // Apply the hit with the selected location and remaining hits
+            weaponDamage: data.weaponDmg || 0,
+            soakValues: {},
+            defenderImg: "icons/svg/mystery-man.svg",
+            applyHitCallback: (location, remainingHits) => {
                 this._applyHit(
-                    data.attacker, 
-                    data.defender, 
-                    data.damage, 
-                    location, 
-                    data.messageId, 
-                    remainingHits, 
+                    data.attacker,
+                    data.defender,
+                    data.damage,
+                    location,
+                    data.messageId,
+                    remainingHits,
                     data.combatId,
-                    data.weaponDmg || 0,  // Pass weapon damage
-                    data.soak || 0        // Pass soak
+                    data.weaponDmg || 0,
+                    data.soak || 0
                 );
             }
         };
         
         // Get battle wear data if we have attacker and defender names
         if (data.attacker && data.defender) {
-            dialogData.battleWear = await this._getBattleWearData(data.attacker, data.defender, 'torso');
+            const bwData = await this._getBattleWearData(data.attacker, data.defender, 'torso');
+            dialogData.battleWear = { attacker: bwData.attacker, defender: bwData.defender };
+
+            const defActor = bwData.actors.defender;
+            if (defActor) {
+                dialogData.defenderImg = bwData.defender.tokenImg;
+                const anat = defActor.system?.anatomy || {};
+                dialogData.soakValues = {
+                    head: Number(anat.head?.soak || 0),
+                    torso: Number(anat.torso?.soak || 0),
+                    'left-arm': Number(anat.leftArm?.soak || 0),
+                    'right-arm': Number(anat.rightArm?.soak || 0),
+                    'left-leg': Number(anat.leftLeg?.soak || 0),
+                    'right-leg': Number(anat.rightLeg?.soak || 0)
+                };
+                dialogData.armorValues = {
+                    head: Number(anat.head?.armor || 0),
+                    torso: Number(anat.torso?.armor || 0),
+                    'left-arm': Number(anat.leftArm?.armor || 0),
+                    'right-arm': Number(anat.rightArm?.armor || 0),
+                    'left-leg': Number(anat.leftLeg?.armor || 0),
+                    'right-leg': Number(anat.rightLeg?.armor || 0)
+                };
+            }
         }
         
         // Create and render a new dialog
@@ -1483,6 +1508,11 @@ export class HitLocationDialog extends Application {
         // Ensure netHits is properly parsed as a number
         this.netHits = parseInt(data.netHits) || 0;
         this.remainingHits = this.netHits;
+        this.weaponDamage = data.weaponDamage || 0;
+        this.soakValues = data.soakValues || {};
+        this.armorValues = data.armorValues || {};
+        this.defenderImg = data.defenderImg || "icons/svg/mystery-man.svg";
+        this.locations = ['head', 'torso', 'left-arm', 'right-arm', 'left-leg', 'right-leg'];
         
         console.log(`HitLocationDialog initialized with netHits: ${this.netHits}, remaining: ${this.remainingHits}`);
         
@@ -1517,10 +1547,20 @@ export class HitLocationDialog extends Application {
     
     /** @override */
     getData(options={}) {
+        const predicted = this.weaponDamage + this.netHits;
+        const netDamage = {};
+        for (const loc of this.locations) {
+            const soak = this.soakValues[loc] || 0;
+            netDamage[loc] = Math.max(predicted - soak, 0);
+        }
         return {
             defenderName: this.data.defenderName || "Target",
+            defenderImg: this.defenderImg,
             damageAmount: this.data.damageAmount || 0,
-            netHits: this.netHits
+            netHits: this.netHits,
+            soakValues: this.soakValues,
+            armorValues: this.armorValues,
+            netDamage
         };
     }
 
@@ -1564,6 +1604,9 @@ export class HitLocationDialog extends Application {
         
         // Update available move buttons
         this.updateAvailableMoves();
+
+        // Update damage preview and soak display
+        this.updateDamagePreview();
     }
     
     /**
@@ -1588,6 +1631,8 @@ export class HitLocationDialog extends Application {
         selectedPart.addClass('selected');
         
         this.selectedLocation = location;
+
+        this.updateDamagePreview();
         
         // Format the location name for display
         const displayLocation = this.formatLocationName(location);
@@ -1668,9 +1713,11 @@ export class HitLocationDialog extends Application {
         // Update remaining hits
         this.remainingHits -= this.moveCost;
         this.element.find('#net-hits-remaining').text(this.remainingHits);
-        
+
         // Select the new location
         this.selectLocationInAttackerPhase(targetLocation);
+
+        this.updateDamagePreview();
     }
     
     /**
@@ -1695,11 +1742,13 @@ export class HitLocationDialog extends Application {
         
         // Update the selected location
         this.selectedLocation = location;
-        
+
         // Update display
         const displayLocation = this.formatLocationName(location);
         this.element.find('#selected-location').text(displayLocation);
-        
+
+        this.updateDamagePreview();
+
         // Update available moves
         this.updateAvailableMoves();
     }
@@ -1716,9 +1765,11 @@ export class HitLocationDialog extends Application {
         // Refund the net hits
         this.remainingHits += this.moveCost;
         this.element.find('#net-hits-remaining').text(this.remainingHits);
-        
+
         // Select the previous location
         this.selectLocationInAttackerPhase(previousLocation);
+
+        this.updateDamagePreview();
     }
     
     /**
@@ -1727,9 +1778,21 @@ export class HitLocationDialog extends Application {
      * @returns {string} The formatted location name
      */
     formatLocationName(location) {
-        return location.split('-').map(word => 
+        return location.split('-').map(word =>
             word.charAt(0).toUpperCase() + word.slice(1)
         ).join(' ');
+    }
+
+    /**
+     * Update damage preview and soak text based on current state
+     */
+    updateDamagePreview() {
+        const damage = this.weaponDamage + this.remainingHits;
+        for (const loc of this.locations) {
+            const soak = this.soakValues[loc] || 0;
+            const net = Math.max(damage - soak, 0);
+            this.element.find(`#net-dmg-${loc}`).text(net);
+        }
     }
     
     /**
@@ -1757,8 +1820,10 @@ export class HitLocationDialog extends Application {
     /** @override */
     activateListeners(html) {
         super.activateListeners(html);
-        
+
         console.log("Activating listeners for hit location dialog");
+
+        this.updateDamagePreview();
         
         // Location labels for defender phase
         const locationLabels = html.find('.location-label');

--- a/styles/hit-location.css
+++ b/styles/hit-location.css
@@ -6,6 +6,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+    position: relative;
 }
 
 .hit-location-selector h2 {
@@ -214,4 +215,69 @@
 
 .random-location-btn:hover, .confirm-location-btn:hover {
     background: rgba(143, 55, 48, 0.9) !important;
-} 
+}
+
+.defender-info {
+    text-align: center;
+}
+
+.defender-phase .defender-info {
+    position: absolute;
+    top: 35px;
+    left: 5px;
+}
+
+.attacker-phase .defender-info {
+    margin-top: 4px;
+}
+
+.defender-info img {
+    width: 50px;
+    height: 50px;
+    border: 1px solid #000;
+}
+
+.defender-info .defender-name {
+    font-size: 0.8em;
+}
+
+.damage-preview, .soak-display {
+    font-size: 0.9em;
+    color: #000;
+    margin-top: 3px;
+}
+
+.location-values {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+/* Location value overlays */
+.location-value {
+    position: absolute;
+    font-size: 0.9rem;
+    color: var(--color-crimson);
+    transform: translate(-50%, -50%);
+    text-align: center;
+    line-height: 1.1;
+    pointer-events: none;
+}
+
+.location-value .net-damage {
+    display: none;
+    color: #000;
+    font-size: 0.75em;
+}
+
+.attacker-phase .location-value .net-damage {
+    display: block;
+}
+
+.location-value.head { top: 10%; left: 50%; }
+.location-value.torso { top: 28%; left: 50%; }
+.location-value.left-arm { top: 40%; left: 24%; }
+.location-value.right-arm { top: 40%; left: 75%; }
+.location-value.left-leg { top: 68%; left: 41%; }
+.location-value.right-leg { top: 68%; left: 59%; }
+

--- a/templates/dialogs/hit-location-selector.hbs
+++ b/templates/dialogs/hit-location-selector.hbs
@@ -1,5 +1,9 @@
 <div class="hit-location-selector">
     <h2>Select Hit Location</h2>
+    <div class="defender-info defender-phase">
+        <img src="{{defenderImg}}" alt="{{defenderName}}">
+        <div class="defender-name">{{defenderName}}</div>
+    </div>
     
     <div class="hit-location-phase defender-phase">
         <div class="compact-info" style="color: #000;">
@@ -18,6 +22,10 @@
             <div class="net-hits-display">
                 <p>Net Hits: <strong id="net-hits-remaining">{{netHits}}</strong></p>
                 <button class="undo-move-btn" disabled>Undo Last Move</button>
+            </div>
+            <div class="defender-info attacker-phase">
+                <img src="{{defenderImg}}" alt="{{defenderName}}">
+                <div class="defender-name">{{defenderName}}</div>
             </div>
         </div>
     </div>
@@ -54,6 +62,14 @@
                          C115,170 120,190 125,230"
                       stroke="#693731" stroke-width="15" fill="none" class="body-part right-leg-part" data-location="right-leg" />
             </svg>
+        </div>
+        <div class="location-values">
+            <div class="location-value head"><span id="soak-head">{{soakValues.head}}</span>({{armorValues.head}}) <span class="net-damage" id="net-dmg-head">{{netDamage.head}}</span></div>
+            <div class="location-value torso"><span id="soak-torso">{{soakValues.torso}}</span>({{armorValues.torso}}) <span class="net-damage" id="net-dmg-torso">{{netDamage.torso}}</span></div>
+            <div class="location-value left-arm"><span id="soak-left-arm">{{lookup soakValues 'left-arm'}}</span>({{lookup armorValues 'left-arm'}}) <span class="net-damage" id="net-dmg-left-arm">{{lookup netDamage 'left-arm'}}</span></div>
+            <div class="location-value right-arm"><span id="soak-right-arm">{{lookup soakValues 'right-arm'}}</span>({{lookup armorValues 'right-arm'}}) <span class="net-damage" id="net-dmg-right-arm">{{lookup netDamage 'right-arm'}}</span></div>
+            <div class="location-value left-leg"><span id="soak-left-leg">{{lookup soakValues 'left-leg'}}</span>({{lookup armorValues 'left-leg'}}) <span class="net-damage" id="net-dmg-left-leg">{{lookup netDamage 'left-leg'}}</span></div>
+            <div class="location-value right-leg"><span id="soak-right-leg">{{lookup soakValues 'right-leg'}}</span>({{lookup armorValues 'right-leg'}}) <span class="net-damage" id="net-dmg-right-leg">{{lookup netDamage 'right-leg'}}</span></div>
         </div>
         
         <!-- Labels (clickable) -->


### PR DESCRIPTION
## Summary
- show soak and net damage over each body part in hit location dialog
- reposition defender token for each phase of dialog
- compute limb soak/armor data during dialog init
- update damage preview logic to fill new per-limb fields

## Testing
- `node --check scripts/hit-location.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841f62a537c832d824fedf34caeaa3f