### PR TITLE
Improve monster HUD layout

### DIFF
--- a/styles/witch-iron.css
+++ b/styles/witch-iron.css
@@ -3788,8 +3788,8 @@ button.roll-skill:hover {
 
 /* Hit location wear layout on monster sheet */
 .witch-iron.sheet.monster .hit-hud {
-  width: 180px;
-  max-width: 180px;
+  width: 360px;
+  max-width: 360px;
   margin: 0 auto 10px;
 }
 
@@ -3846,4 +3846,20 @@ button.roll-skill:hover {
 
 .witch-iron.sheet.monster .weapon-wear-container .wear-max {
   font-size: 0.8rem;
+}
+
+/* Layout grid for monster stats and hit HUD */
+.witch-iron.sheet.monster .monster-stats-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 10px;
+  align-items: start;
+  margin-bottom: 10px;
+}
+
+.witch-iron.sheet.monster .monster-stats-grid .monster-battlewear {
+  grid-row: span 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }

--- a/templates/actors/monster-sheet.hbs
+++ b/templates/actors/monster-sheet.hbs
@@ -106,39 +106,36 @@
         <div class="tab" data-group="primary" data-tab="stats">
           <div class="stats-content">
             <h2>Monster Stats</h2>
-            <div class="grid grid-2col">
-              <div class="form-group">
+            <div class="monster-stats-grid">
+              <div class="form-group hit-dice">
                 <label>Hit Dice</label>
                 <select name="system.stats.hitDice.value">
                   {{selectOptions hitDiceOptions selected=system.stats.hitDice.value localize=false}}
                 </select>
               </div>
-              
-              <div class="form-group">
-                <label>Size</label>
-                <select name="system.stats.size.value">
-                  {{selectOptions sizes selected=system.stats.size.value localize=false}}
-                </select>
-              </div>
-            </div>
-            
-            <div class="grid grid-2col">
-              <div class="form-group">
+
+              <div class="form-group weapon-type">
                 <label>Weapon Type</label>
                 <select name="system.stats.weaponType.value">
                   {{selectOptions weaponTypes selected=system.stats.weaponType.value localize=false}}
                 </select>
               </div>
-              
-              <div class="form-group">
+
+              <div class="form-group size">
+                <label>Size</label>
+                <select name="system.stats.size.value">
+                  {{selectOptions sizes selected=system.stats.size.value localize=false}}
+                </select>
+              </div>
+
+              <div class="form-group armor-type">
                 <label>Armor Type</label>
                 <select name="system.stats.armorType.value">
                   {{selectOptions armorTypes selected=system.stats.armorType.value localize=false}}
                 </select>
               </div>
-            </div>
 
-            <div class="monster-battlewear">
+              <div class="monster-battlewear">
               <div class="hit-hud monster-wear-layout">
                 <div class="hud-inner">
                   <div class="body-container">


### PR DESCRIPTION
## Summary
- enlarge the monster hit-location HUD to 360px
- create a two-row layout with the HUD beside the stat selections
- update the monster template to use the new grid

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841f94c6d44832daf6e1589b72e3d20