### PR TITLE
Enhance hit location dialog

### DIFF
--- a/scripts/hit-location.js
+++ b/scripts/hit-location.js
@@ -183,6 +183,8 @@ export class HitLocationSelector {
             combatId: data.combatId,
             weaponDamage: data.weaponDmg || 0,
             soakValues: {},
+            armorValues: {},
+            locations: ["head","torso","left-arm","right-arm","left-leg","right-leg"],
             defenderImg: "icons/svg/mystery-man.svg",
             applyHitCallback: (location, remainingHits) => {
                 this._applyHit(
@@ -211,10 +213,18 @@ export class HitLocationSelector {
                 dialogData.soakValues = {
                     head: Number(anat.head?.soak || 0),
                     torso: Number(anat.torso?.soak || 0),
-                    'left-arm': Number(anat.leftArm?.soak || 0),
-                    'right-arm': Number(anat.rightArm?.soak || 0),
-                    'left-leg': Number(anat.leftLeg?.soak || 0),
-                    'right-leg': Number(anat.rightLeg?.soak || 0)
+                    leftArm: Number(anat.leftArm?.soak || 0),
+                    rightArm: Number(anat.rightArm?.soak || 0),
+                    leftLeg: Number(anat.leftLeg?.soak || 0),
+                    rightLeg: Number(anat.rightLeg?.soak || 0)
+                };
+                dialogData.armorValues = {
+                    head: Number(anat.head?.armor || 0),
+                    torso: Number(anat.torso?.armor || 0),
+                    leftArm: Number(anat.leftArm?.armor || 0),
+                    rightArm: Number(anat.rightArm?.armor || 0),
+                    leftLeg: Number(anat.leftLeg?.armor || 0),
+                    rightLeg: Number(anat.rightLeg?.armor || 0)
                 };
             }
         }
@@ -1512,6 +1522,8 @@ export class HitLocationDialog extends Application {
         this.remainingHits = this.netHits;
         this.weaponDamage = data.weaponDamage || 0;
         this.soakValues = data.soakValues || {};
+        this.armorValues = data.armorValues || {};
+        this.locations = data.locations || ["head","torso","left-arm","right-arm","left-leg","right-leg"];
         this.defenderImg = data.defenderImg || "icons/svg/mystery-man.svg";
         
         console.log(`HitLocationDialog initialized with netHits: ${this.netHits}, remaining: ${this.remainingHits}`);
@@ -1540,22 +1552,31 @@ export class HitLocationDialog extends Application {
             template: "systems/witch-iron/templates/dialogs/hit-location-selector.hbs",
             width: 400,
             height: 600,
-            classes: ["witch-iron", "hit-location-dialog"],
+            classes: ["witch-iron", "hit-location-dialog", "defender-mode"],
             resizable: true
         });
     }
     
     /** @override */
     getData(options={}) {
-        const defaultLoc = 'torso';
-        const soak = this.soakValues[defaultLoc] || 0;
+        const damage = this.weaponDamage + this.remainingHits;
+        const locationData = {};
+        const map = { 'head':'head','torso':'torso','left-arm':'leftArm','right-arm':'rightArm','left-leg':'leftLeg','right-leg':'rightLeg' };
+        for (const loc of this.locations) {
+            const key = map[loc] || loc;
+            const soak = this.soakValues[key] || 0;
+            const armor = this.armorValues[key] || 0;
+            const net = Math.max(0, damage - soak);
+            locationData[loc] = { soak, armor, net };
+        }
         return {
             defenderName: this.data.defenderName || "Target",
             defenderImg: this.defenderImg,
             damageAmount: this.data.damageAmount || 0,
             netHits: this.netHits,
-            damagePreview: this.weaponDamage + this.netHits,
-            currentSoak: soak
+            damagePreview: damage,
+            phase: this.phase,
+            locations: locationData
         };
     }
 
@@ -1566,6 +1587,7 @@ export class HitLocationDialog extends Application {
     moveToAttackerPhase(initialLocation) {
         console.log("Moving to attacker phase");
         this.phase = "attacker";
+        this.element.removeClass('defender-mode').addClass('attacker-mode');
         
         // Hide defender phase elements
         this.element.find('.defender-phase').hide();
@@ -1782,11 +1804,16 @@ export class HitLocationDialog extends Application {
      * Update damage preview and soak text based on current state
      */
     updateDamagePreview() {
-        const loc = this.selectedLocation || 'torso';
-        const soak = this.soakValues[loc] || 0;
         const damage = this.weaponDamage + this.remainingHits;
-        this.element.find('#damage-preview').text(damage);
-        this.element.find('#location-soak').text(soak);
+        const map = { 'head':'head','torso':'torso','left-arm':'leftArm','right-arm':'rightArm','left-leg':'leftLeg','right-leg':'rightLeg' };
+        for (const loc of this.locations) {
+            const key = map[loc] || loc;
+            const soak = this.soakValues[key] || 0;
+            const net = Math.max(0, damage - soak);
+            this.element.find(`.location-value[data-location="${loc}"] .net-dmg`).text(net);
+            this.element.find(`.location-value[data-location="${loc}"] .soak`).text(this.soakValues[key] || 0);
+            this.element.find(`.location-value[data-location="${loc}"] .armor`).text(this.armorValues[key] || 0);
+        }
     }
     
     /**

--- a/styles/hit-location.css
+++ b/styles/hit-location.css
@@ -218,10 +218,16 @@
 }
 
 .defender-info {
-    position: absolute;
-    top: 5px;
-    right: 5px;
     text-align: center;
+}
+
+.defender-mode .defender-info {
+    align-self: flex-start;
+    margin: 5px 0 5px 5px;
+}
+
+.attacker-mode .defender-info {
+    margin: 5px auto;
 }
 
 .defender-info img {
@@ -238,4 +244,31 @@
     font-size: 0.9em;
     color: #000;
     margin-top: 3px;
+}
+
+.location-value {
+    position: absolute;
+    font-size: 0.9rem;
+    color: var(--color-crimson);
+    transform: translate(-50%, -50%);
+    text-align: center;
+    pointer-events: none;
+}
+
+.location-value .net-dmg {
+    display: block;
+    font-size: 0.75em;
+}
+
+.location-value.head { top: 10%; left: 50%; }
+.location-value.torso { top: 28%; left: 50%; }
+.location-value.left-arm { top: 40%; left: 24%; }
+.location-value.right-arm { top: 40%; left: 75%; }
+.location-value.left-leg { top: 68%; left: 41%; }
+.location-value.right-leg { top: 68%; left: 59%; }
+
+.values-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
 }

--- a/templates/dialogs/hit-location-selector.hbs
+++ b/templates/dialogs/hit-location-selector.hbs
@@ -23,11 +23,9 @@
                 <p>Net Hits: <strong id="net-hits-remaining">{{netHits}}</strong></p>
                 <button class="undo-move-btn" disabled>Undo Last Move</button>
             </div>
-            <div class="damage-preview">Damage: <strong id="damage-preview">{{damagePreview}}</strong></div>
-            <div class="soak-display">Soak: <strong id="location-soak">{{currentSoak}}</strong></div>
         </div>
     </div>
-    
+
     <div class="hit-location-body">
         <!-- Body Silhouette -->
         <div class="body-outline">
@@ -60,6 +58,40 @@
                          C115,170 120,190 125,230"
                       stroke="#693731" stroke-width="15" fill="none" class="body-part right-leg-part" data-location="right-leg" />
             </svg>
+        </div>
+        <div class="values-layer">
+            <div class="location-value head" data-location="head">
+                <span class="soak">{{locations.head.soak}}</span>(<span class="armor">{{locations.head.armor}}</span>)
+                {{#if (eq phase 'attacker')}}<span class="net-dmg">{{locations.head.net}}</span>{{/if}}
+            </div>
+            <div class="location-value torso" data-location="torso">
+                <span class="soak">{{locations.torso.soak}}</span>(<span class="armor">{{locations.torso.armor}}</span>)
+                {{#if (eq phase 'attacker')}}<span class="net-dmg">{{locations.torso.net}}</span>{{/if}}
+            </div>
+            <div class="location-value left-arm" data-location="left-arm">
+                {{#with (lookup locations 'left-arm') as |loc|}}
+                <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
+                {{#if (eq ../phase 'attacker')}}<span class="net-dmg">{{loc.net}}</span>{{/if}}
+                {{/with}}
+            </div>
+            <div class="location-value right-arm" data-location="right-arm">
+                {{#with (lookup locations 'right-arm') as |loc|}}
+                <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
+                {{#if (eq ../phase 'attacker')}}<span class="net-dmg">{{loc.net}}</span>{{/if}}
+                {{/with}}
+            </div>
+            <div class="location-value left-leg" data-location="left-leg">
+                {{#with (lookup locations 'left-leg') as |loc|}}
+                <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
+                {{#if (eq ../phase 'attacker')}}<span class="net-dmg">{{loc.net}}</span>{{/if}}
+                {{/with}}
+            </div>
+            <div class="location-value right-leg" data-location="right-leg">
+                {{#with (lookup locations 'right-leg') as |loc|}}
+                <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
+                {{#if (eq ../phase 'attacker')}}<span class="net-dmg">{{loc.net}}</span>{{/if}}
+                {{/with}}
+            </div>
         </div>
         
         <!-- Labels (clickable) -->


### PR DESCRIPTION
## Summary
- collect soak & armor for each limb when the hit-location dialog opens
- show limb soak values and net damage on the body diagram
- position the defender token depending on phase
- style location value overlays

## Testing
- `echo 'No tests'`

------
https://chatgpt.com/codex/tasks/task_e_68420e81ba40832d95178c93cbbbdecc