### PR TITLE
Align attacker and defender phases

### DIFF
--- a/scripts/hit-location.js
+++ b/scripts/hit-location.js
@@ -1633,7 +1633,8 @@ export class HitLocationDialog extends Application {
         });
         
         // Force redraw of the UI
-        this.element.find('.attacker-phase, .attacker-buttons').css('display', 'block');
+        this.element.find('.attacker-phase').css('display', 'block');
+        this.element.find('.attacker-buttons').css('display', 'flex');
         
         // Update available move buttons
         this.updateAvailableMoves();

--- a/styles/hit-location.css
+++ b/styles/hit-location.css
@@ -219,15 +219,15 @@
 
 .defender-info {
     text-align: center;
+    display: flex;
+    align-items: center;
+    gap: 5px;
 }
 
-.defender-mode .defender-info {
+.defender-mode .defender-info,
+.attacker-mode .defender-info {
     align-self: flex-start;
     margin: 5px 0 5px 5px;
-}
-
-.attacker-mode .defender-info {
-    margin: 5px auto;
 }
 
 .defender-info img {
@@ -238,6 +238,12 @@
 
 .defender-info .defender-name {
     font-size: 0.8em;
+}
+
+.defender-info .damage-amount {
+    font-size: 0.9em;
+    font-weight: bold;
+    margin-left: 5px;
 }
 
 .damage-preview, .soak-display {

--- a/templates/dialogs/hit-location-selector.hbs
+++ b/templates/dialogs/hit-location-selector.hbs
@@ -2,12 +2,12 @@
     <h2>Select Hit Location</h2>
     <div class="defender-info">
         <img src="{{defenderImg}}" alt="{{defenderName}}">
-        <div class="defender-name">{{defenderName}}</div>
+        <span class="defender-name">{{defenderName}}</span>
+        <span class="damage-amount">{{damageAmount}} dmg</span>
     </div>
     
     <div class="hit-location-phase defender-phase">
         <div class="compact-info" style="color: #000;">
-            <p><strong id="damage-amount">{{damageAmount}}</strong> damage to <strong id="defender-name">{{defenderName}}</strong></p>
             {{#if battleWear}}
             <div class="battle-wear-info">
                 <p>Weapon Wear: <strong>{{battleWear.attacker.currentWear}}/{{battleWear.attacker.maxWear}}</strong> | Armor Wear: <strong>{{battleWear.defender.currentWear}}/{{battleWear.defender.maxWear}}</strong></p>


### PR DESCRIPTION
## Summary
- unify attacker and defender token layout
- show damage amount next to the defender name
- keep attacker buttons in a flex row

## Testing
- `npm test` *(fails: cannot find package.json)*
- `pytest` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684212f95ca4832d86db5f90e567c2d1