### PR TITLE
Align attacker and defender phases

### DIFF
--- a/styles/hit-location.css
+++ b/styles/hit-location.css
@@ -219,15 +219,15 @@
 
 .defender-info {
     text-align: center;
+    display: flex;
+    align-items: center;
+    gap: 5px;
 }
 
-.defender-mode .defender-info {
+.defender-mode .defender-info,
+.attacker-mode .defender-info {
     align-self: flex-start;
     margin: 5px 0 5px 5px;
-}
-
-.attacker-mode .defender-info {
-    margin: 5px auto;
 }
 
 .defender-info img {
@@ -238,6 +238,12 @@
 
 .defender-info .defender-name {
     font-size: 0.8em;
+}
+
+.defender-info .damage-amount {
+    font-size: 0.9em;
+    font-weight: bold;
+    margin-left: 5px;
 }
 
 .damage-preview, .soak-display {

--- a/templates/dialogs/hit-location-selector.hbs
+++ b/templates/dialogs/hit-location-selector.hbs
@@ -1,13 +1,12 @@
 <div class="hit-location-selector">
     <h2>Select Hit Location</h2>
-    <div class="defender-info">
-        <img src="{{defenderImg}}" alt="{{defenderName}}">
-        <div class="defender-name">{{defenderName}}</div>
-    </div>
-    
     <div class="hit-location-phase defender-phase">
+        <div class="defender-info">
+            <img src="{{defenderImg}}" alt="{{defenderName}}">
+            <span class="defender-name">{{defenderName}}</span>
+            <span class="damage-amount">{{damageAmount}} dmg</span>
+        </div>
         <div class="compact-info" style="color: #000;">
-            <p><strong id="damage-amount">{{damageAmount}}</strong> damage to <strong id="defender-name">{{defenderName}}</strong></p>
             {{#if battleWear}}
             <div class="battle-wear-info">
                 <p>Weapon Wear: <strong>{{battleWear.attacker.currentWear}}/{{battleWear.attacker.maxWear}}</strong> | Armor Wear: <strong>{{battleWear.defender.currentWear}}/{{battleWear.defender.maxWear}}</strong></p>
@@ -23,6 +22,11 @@
                 <p>Net Hits: <strong id="net-hits-remaining">{{netHits}}</strong></p>
                 <button class="undo-move-btn" disabled>Undo Last Move</button>
             </div>
+        </div>
+        <div class="defender-info">
+            <img src="{{defenderImg}}" alt="{{defenderName}}">
+            <span class="defender-name">{{defenderName}}</span>
+            <span class="damage-amount">{{damageAmount}} dmg</span>
         </div>
     </div>
 
@@ -62,34 +66,34 @@
         <div class="values-layer">
             <div class="location-value head" data-location="head">
                 <span class="soak">{{locations.head.soak}}</span>(<span class="armor">{{locations.head.armor}}</span>)
-                {{#if (eq phase 'attacker')}}<span class="net-dmg">{{locations.head.net}}</span>{{/if}}
+                <span class="net-dmg">{{locations.head.net}}</span>
             </div>
             <div class="location-value torso" data-location="torso">
                 <span class="soak">{{locations.torso.soak}}</span>(<span class="armor">{{locations.torso.armor}}</span>)
-                {{#if (eq phase 'attacker')}}<span class="net-dmg">{{locations.torso.net}}</span>{{/if}}
+                <span class="net-dmg">{{locations.torso.net}}</span>
             </div>
             <div class="location-value left-arm" data-location="left-arm">
                 {{#with (lookup locations 'left-arm') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                {{#if (eq ../phase 'attacker')}}<span class="net-dmg">{{loc.net}}</span>{{/if}}
+                <span class="net-dmg">{{loc.net}}</span>
                 {{/with}}
             </div>
             <div class="location-value right-arm" data-location="right-arm">
                 {{#with (lookup locations 'right-arm') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                {{#if (eq ../phase 'attacker')}}<span class="net-dmg">{{loc.net}}</span>{{/if}}
+                <span class="net-dmg">{{loc.net}}</span>
                 {{/with}}
             </div>
             <div class="location-value left-leg" data-location="left-leg">
                 {{#with (lookup locations 'left-leg') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                {{#if (eq ../phase 'attacker')}}<span class="net-dmg">{{loc.net}}</span>{{/if}}
+                <span class="net-dmg">{{loc.net}}</span>
                 {{/with}}
             </div>
             <div class="location-value right-leg" data-location="right-leg">
                 {{#with (lookup locations 'right-leg') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                {{#if (eq ../phase 'attacker')}}<span class="net-dmg">{{loc.net}}</span>{{/if}}
+                <span class="net-dmg">{{loc.net}}</span>
                 {{/with}}
             </div>
         </div>


### PR DESCRIPTION
## Summary
- unify attacker and defender token layout
- show per-limb damage amounts
- display projected damage for adjacent moves

## Testing
- `npm test` *(fails: cannot find package.json)*
- `pytest` *(fails: no tests collected)*

------
https://chatgpt.com/codex/tasks/task_e_684212f95ca4832d86db5f90e567c2d1