### PR TITLE
Adjust hit preview rows

### DIFF
--- a/scripts/hit-location.js
+++ b/scripts/hit-location.js
@@ -1821,13 +1821,33 @@ export class HitLocationDialog extends Application {
      * Update damage preview and soak text based on current state
      */
     updateDamagePreview() {
-        const damage = this.weaponDamage + this.remainingHits;
         const map = { 'head':'head','torso':'torso','left-arm':'leftArm','right-arm':'rightArm','left-leg':'leftLeg','right-leg':'rightLeg' };
+
         for (const loc of this.locations) {
             const key = map[loc] || loc;
             const soak = this.soakValues[key] || 0;
+            let hits;
+            let show = true;
+
+            if (this.phase === 'defender') {
+                hits = this.netHits;
+            } else {
+                if (loc === this.selectedLocation) {
+                    hits = this.remainingHits;
+                } else if ((this.adjacencyMap[this.selectedLocation] || []).includes(loc)) {
+                    hits = Math.max(this.remainingHits - this.moveCost, 0);
+                } else {
+                    show = false;
+                    hits = this.remainingHits;
+                }
+            }
+
+            const damage = this.weaponDamage + hits;
             const net = Math.max(0, damage - soak);
-            this.element.find(`.location-value[data-location="${loc}"] .net-dmg`).text(net);
+
+            const value = show ? net : '';
+
+            this.element.find(`.location-value[data-location="${loc}"] .net-dmg`).text(value);
             this.element.find(`.location-value[data-location="${loc}"] .soak`).text(this.soakValues[key] || 0);
             this.element.find(`.location-value[data-location="${loc}"] .armor`).text(this.armorValues[key] || 0);
         }

--- a/styles/hit-location.css
+++ b/styles/hit-location.css
@@ -240,11 +240,6 @@
     font-size: 0.8em;
 }
 
-.defender-info .damage-amount {
-    font-size: 0.9em;
-    font-weight: bold;
-    margin-left: 5px;
-}
 
 .damage-preview, .soak-display {
     font-size: 0.9em;
@@ -264,6 +259,7 @@
 .location-value .net-dmg {
     display: block;
     font-size: 0.75em;
+    color: #b52b2b;
 }
 
 .location-value.head { top: 12%; left: 50%; }

--- a/templates/dialogs/hit-location-selector.hbs
+++ b/templates/dialogs/hit-location-selector.hbs
@@ -1,11 +1,5 @@
 <div class="hit-location-selector">
     <h2>Select Hit Location</h2>
-    <div class="defender-info">
-        <img src="{{defenderImg}}" alt="{{defenderName}}">
-        <span class="defender-name">{{defenderName}}</span>
-        <span class="damage-amount">{{damageAmount}} dmg</span>
-    </div>
-    
     <div class="hit-location-phase defender-phase">
         <div class="compact-info" style="color: #000;">
             {{#if battleWear}}
@@ -15,13 +9,21 @@
             </div>
             {{/if}}
         </div>
+        <div class="defender-info">
+            <img src="{{defenderImg}}" alt="{{defenderName}}">
+            <span class="defender-name">{{defenderName}}</span>
+        </div>
     </div>
-    
+
     <div class="hit-location-phase attacker-phase" style="display: none;">
         <div class="compact-info">
             <div class="net-hits-display">
                 <p>Net Hits: <strong id="net-hits-remaining">{{netHits}}</strong></p>
                 <button class="undo-move-btn" disabled>Undo Last Move</button>
+            </div>
+            <div class="defender-info">
+                <img src="{{defenderImg}}" alt="{{defenderName}}">
+                <span class="defender-name">{{defenderName}}</span>
             </div>
         </div>
     </div>
@@ -62,34 +64,34 @@
         <div class="values-layer">
             <div class="location-value head" data-location="head">
                 <span class="soak">{{locations.head.soak}}</span>(<span class="armor">{{locations.head.armor}}</span>)
-                {{#if (eq phase 'attacker')}}<span class="net-dmg">{{locations.head.net}}</span>{{/if}}
+                <span class="net-dmg">Net Dmg: {{locations.head.net}}</span>
             </div>
             <div class="location-value torso" data-location="torso">
                 <span class="soak">{{locations.torso.soak}}</span>(<span class="armor">{{locations.torso.armor}}</span>)
-                {{#if (eq phase 'attacker')}}<span class="net-dmg">{{locations.torso.net}}</span>{{/if}}
+                <span class="net-dmg">Net Dmg: {{locations.torso.net}}</span>
             </div>
             <div class="location-value left-arm" data-location="left-arm">
                 {{#with (lookup locations 'left-arm') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                {{#if (eq ../phase 'attacker')}}<span class="net-dmg">{{loc.net}}</span>{{/if}}
+                <span class="net-dmg">Net Dmg: {{loc.net}}</span>
                 {{/with}}
             </div>
             <div class="location-value right-arm" data-location="right-arm">
                 {{#with (lookup locations 'right-arm') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                {{#if (eq ../phase 'attacker')}}<span class="net-dmg">{{loc.net}}</span>{{/if}}
+                <span class="net-dmg">Net Dmg: {{loc.net}}</span>
                 {{/with}}
             </div>
             <div class="location-value left-leg" data-location="left-leg">
                 {{#with (lookup locations 'left-leg') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                {{#if (eq ../phase 'attacker')}}<span class="net-dmg">{{loc.net}}</span>{{/if}}
+                <span class="net-dmg">Net Dmg: {{loc.net}}</span>
                 {{/with}}
             </div>
             <div class="location-value right-leg" data-location="right-leg">
                 {{#with (lookup locations 'right-leg') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                {{#if (eq ../phase 'attacker')}}<span class="net-dmg">{{loc.net}}</span>{{/if}}
+                <span class="net-dmg">Net Dmg: {{loc.net}}</span>
                 {{/with}}
             </div>
         </div>


### PR DESCRIPTION
## Summary
- show the defender token under the net-hits panel and also in defender phase
- always list net damage values for each limb
- update damage preview logic for selected and adjacent limb projections
- mark net damage text clearly and remove old damage display

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68422c26d454832d8b76662aa2ca58aa