### PR TITLE
Clarify net damage display

### DIFF
--- a/styles/hit-location.css
+++ b/styles/hit-location.css
@@ -240,11 +240,6 @@
     font-size: 0.8em;
 }
 
-.defender-info .damage-amount {
-    font-size: 0.9em;
-    font-weight: bold;
-    margin-left: 5px;
-}
 
 .damage-preview, .soak-display {
     font-size: 0.9em;
@@ -264,6 +259,8 @@
 .location-value .net-dmg {
     display: block;
     font-size: 0.75em;
+    font-weight: bold;
+    color: #a52a2a;
 }
 
 .location-value.head { top: 12%; left: 50%; }

--- a/templates/dialogs/hit-location-selector.hbs
+++ b/templates/dialogs/hit-location-selector.hbs
@@ -12,7 +12,6 @@
         <div class="defender-info">
             <img src="{{defenderImg}}" alt="{{defenderName}}">
             <span class="defender-name">{{defenderName}}</span>
-            <span class="damage-amount">{{damageAmount}} dmg</span>
         </div>
     </div>
 
@@ -25,7 +24,6 @@
             <div class="defender-info">
                 <img src="{{defenderImg}}" alt="{{defenderName}}">
                 <span class="defender-name">{{defenderName}}</span>
-                <span class="damage-amount">{{damageAmount}} dmg</span>
             </div>
         </div>
     </div>
@@ -66,34 +64,34 @@
         <div class="values-layer">
             <div class="location-value head" data-location="head">
                 <span class="soak">{{locations.head.soak}}</span>(<span class="armor">{{locations.head.armor}}</span>)
-                <span class="net-dmg">{{locations.head.net}}</span>
+                <span class="net-dmg">Net Dmg: {{locations.head.net}}</span>
             </div>
             <div class="location-value torso" data-location="torso">
                 <span class="soak">{{locations.torso.soak}}</span>(<span class="armor">{{locations.torso.armor}}</span>)
-                <span class="net-dmg">{{locations.torso.net}}</span>
+                <span class="net-dmg">Net Dmg: {{locations.torso.net}}</span>
             </div>
             <div class="location-value left-arm" data-location="left-arm">
                 {{#with (lookup locations 'left-arm') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                <span class="net-dmg">{{loc.net}}</span>
+                <span class="net-dmg">Net Dmg: {{loc.net}}</span>
                 {{/with}}
             </div>
             <div class="location-value right-arm" data-location="right-arm">
                 {{#with (lookup locations 'right-arm') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                <span class="net-dmg">{{loc.net}}</span>
+                <span class="net-dmg">Net Dmg: {{loc.net}}</span>
                 {{/with}}
             </div>
             <div class="location-value left-leg" data-location="left-leg">
                 {{#with (lookup locations 'left-leg') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                <span class="net-dmg">{{loc.net}}</span>
+                <span class="net-dmg">Net Dmg: {{loc.net}}</span>
                 {{/with}}
             </div>
             <div class="location-value right-leg" data-location="right-leg">
                 {{#with (lookup locations 'right-leg') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                <span class="net-dmg">{{loc.net}}</span>
+                <span class="net-dmg">Net Dmg: {{loc.net}}</span>
                 {{/with}}
             </div>
         </div>


### PR DESCRIPTION
## Summary
- remove outdated damage number from hit location phases
- add "Net Dmg" labels for each limb
- update styling for clearer net damage

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68422f0cb960832da6f6093967d6b0d0