### PR TITLE
Improve battle wear HUD and header

### DIFF
--- a/styles/hit-location-hud.css
+++ b/styles/hit-location-hud.css
@@ -71,7 +71,7 @@
   color: #fff;
   padding: 1px 4px 1px 20px;
   border-radius: 3px;
-  font-size: 1.3rem;
+  font-size: 0.975rem;
   pointer-events: auto;
 }
 

--- a/styles/witch-iron.css
+++ b/styles/witch-iron.css
@@ -3830,6 +3830,17 @@ button.roll-skill:hover {
   margin-top: 6px;
 }
 
+.witch-iron.sheet.monster .battle-wear-heading {
+  text-align: center;
+  margin: 0 0 6px;
+  font-size: 1.2rem;
+  color: var(--color-primary);
+}
+
+.witch-iron.sheet.monster .weapon-wear-label {
+  font-weight: bold;
+}
+
 .witch-iron.sheet.monster .hit-hud .wear-label {
   position: absolute;
   top: 0;

--- a/templates/actors/monster-sheet.hbs
+++ b/templates/actors/monster-sheet.hbs
@@ -237,8 +237,9 @@
         {{!-- Injuries Tab --}}
         <div class="tab" data-group="primary" data-tab="injuries">
           <div class="monster-battlewear">
+            <h2 class="battle-wear-heading">Battle Wear</h2>
             <div class="weapon-wear-container">
-              <span>Weapon Wear</span>
+              <span class="weapon-wear-label"><strong>Weapon Wear</strong></span>
               <button type="button" class="battle-wear-minus" data-type="weapon"><i class="fas fa-minus"></i></button>
               <span class="battle-wear-value" data-type="weapon">{{system.battleWear.weapon.value}}</span>/<span class="wear-max">{{system.derived.weaponBonusMax}}</span>
               <button type="button" class="battle-wear-plus" data-type="weapon"><i class="fas fa-plus"></i></button>


### PR DESCRIPTION
## Summary
- shrink HUD condition icons
- add battle wear header to the monster sheet
- style weapon wear header text

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68423118d00c832da05c11e6603bbafb