### PR TITLE
Clarify net damage and overlay info

### DIFF
--- a/scripts/hit-location.js
+++ b/scripts/hit-location.js
@@ -1846,8 +1846,9 @@ export class HitLocationDialog extends Application {
             const net = Math.max(0, damage - soak);
 
             const value = show ? net : '';
+            const display = value !== '' ? `Net Dmg: ${value}` : '';
 
-            this.element.find(`.location-value[data-location="${loc}"] .net-dmg`).text(value);
+            this.element.find(`.location-value[data-location="${loc}"] .net-dmg`).text(display);
             this.element.find(`.location-value[data-location="${loc}"] .soak`).text(this.soakValues[key] || 0);
             this.element.find(`.location-value[data-location="${loc}"] .armor`).text(this.armorValues[key] || 0);
         }

--- a/styles/hit-location.css
+++ b/styles/hit-location.css
@@ -230,6 +230,15 @@
     margin: 5px 0 5px 5px;
 }
 
+/* Overlay defender info in the hit location body */
+.hit-location-body .defender-info {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    margin: 0;
+    z-index: 5;
+}
+
 .defender-info img {
     width: 50px;
     height: 50px;
@@ -240,11 +249,6 @@
     font-size: 0.8em;
 }
 
-.defender-info .damage-amount {
-    font-size: 0.9em;
-    font-weight: bold;
-    margin-left: 5px;
-}
 
 .damage-preview, .soak-display {
     font-size: 0.9em;
@@ -263,7 +267,9 @@
 
 .location-value .net-dmg {
     display: block;
-    font-size: 0.75em;
+    font-size: 1em;
+    font-weight: bold;
+    color: #a52a2a;
 }
 
 .location-value.head { top: 12%; left: 50%; }
@@ -272,6 +278,28 @@
 .location-value.right-arm { top: 45%; left: 75%; }
 .location-value.left-leg { top: 80%; left: 23%; }
 .location-value.right-leg { top: 80%; left: 77%; }
+
+/* Ensure dialog values override HUD styles */
+.hit-location-selector .location-value {
+    position: absolute;
+    font-size: 0.9rem;
+    color: var(--color-crimson);
+    transform: translate(-50%, -50%);
+    text-align: center;
+    pointer-events: none;
+}
+.hit-location-selector .location-value .net-dmg {
+    display: block;
+    font-size: 1em;
+    font-weight: bold;
+    color: #a52a2a;
+}
+.hit-location-selector .location-value.head { top: 12%; left: 50%; }
+.hit-location-selector .location-value.torso { top: 34%; left: 50%; }
+.hit-location-selector .location-value.left-arm { top: 45%; left: 24%; }
+.hit-location-selector .location-value.right-arm { top: 45%; left: 75%; }
+.hit-location-selector .location-value.left-leg { top: 80%; left: 23%; }
+.hit-location-selector .location-value.right-leg { top: 80%; left: 77%; }
 
 .values-layer {
     position: absolute;

--- a/templates/dialogs/hit-location-selector.hbs
+++ b/templates/dialogs/hit-location-selector.hbs
@@ -9,11 +9,6 @@
             </div>
             {{/if}}
         </div>
-        <div class="defender-info">
-            <img src="{{defenderImg}}" alt="{{defenderName}}">
-            <span class="defender-name">{{defenderName}}</span>
-            <span class="damage-amount">{{damageAmount}} dmg</span>
-        </div>
     </div>
 
     <div class="hit-location-phase attacker-phase" style="display: none;">
@@ -22,15 +17,14 @@
                 <p>Net Hits: <strong id="net-hits-remaining">{{netHits}}</strong></p>
                 <button class="undo-move-btn" disabled>Undo Last Move</button>
             </div>
-            <div class="defender-info">
-                <img src="{{defenderImg}}" alt="{{defenderName}}">
-                <span class="defender-name">{{defenderName}}</span>
-                <span class="damage-amount">{{damageAmount}} dmg</span>
-            </div>
         </div>
     </div>
 
     <div class="hit-location-body">
+        <div class="defender-info">
+            <img src="{{defenderImg}}" alt="{{defenderName}}">
+            <span class="defender-name">{{defenderName}}</span>
+        </div>
         <!-- Body Silhouette -->
         <div class="body-outline">
             <svg viewBox="0 0 200 280" xmlns="http://www.w3.org/2000/svg">
@@ -66,34 +60,34 @@
         <div class="values-layer">
             <div class="location-value head" data-location="head">
                 <span class="soak">{{locations.head.soak}}</span>(<span class="armor">{{locations.head.armor}}</span>)
-                <span class="net-dmg">{{locations.head.net}}</span>
+                <span class="net-dmg">Net Dmg: {{locations.head.net}}</span>
             </div>
             <div class="location-value torso" data-location="torso">
                 <span class="soak">{{locations.torso.soak}}</span>(<span class="armor">{{locations.torso.armor}}</span>)
-                <span class="net-dmg">{{locations.torso.net}}</span>
+                <span class="net-dmg">Net Dmg: {{locations.torso.net}}</span>
             </div>
             <div class="location-value left-arm" data-location="left-arm">
                 {{#with (lookup locations 'left-arm') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                <span class="net-dmg">{{loc.net}}</span>
+                <span class="net-dmg">Net Dmg: {{loc.net}}</span>
                 {{/with}}
             </div>
             <div class="location-value right-arm" data-location="right-arm">
                 {{#with (lookup locations 'right-arm') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                <span class="net-dmg">{{loc.net}}</span>
+                <span class="net-dmg">Net Dmg: {{loc.net}}</span>
                 {{/with}}
             </div>
             <div class="location-value left-leg" data-location="left-leg">
                 {{#with (lookup locations 'left-leg') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                <span class="net-dmg">{{loc.net}}</span>
+                <span class="net-dmg">Net Dmg: {{loc.net}}</span>
                 {{/with}}
             </div>
             <div class="location-value right-leg" data-location="right-leg">
                 {{#with (lookup locations 'right-leg') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                <span class="net-dmg">{{loc.net}}</span>
+                <span class="net-dmg">Net Dmg: {{loc.net}}</span>
                 {{/with}}
             </div>
         </div>


### PR DESCRIPTION
## Summary
- overlay defender token info directly on hit location body
- enlarge the net damage font to match limb labels
- ensure script displays `Net Dmg:` label

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68422f0cb960832da6f6093967d6b0d0