### PR TITLE
Overlay defender info and enlarge damage text

### DIFF
--- a/styles/hit-location.css
+++ b/styles/hit-location.css
@@ -224,11 +224,17 @@
     gap: 5px;
 }
 
-.defender-mode .defender-info,
-.attacker-mode .defender-info {
-    align-self: flex-start;
-    margin: 5px 0 5px 5px;
+.hit-location-body .defender-info {
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin: 5px;
+    flex-direction: column;
+    background: rgba(0, 0, 0, 0.5);
+    padding: 2px 4px;
+    border-radius: 3px;
 }
+
 
 .defender-info img {
     width: 50px;
@@ -237,7 +243,8 @@
 }
 
 .defender-info .defender-name {
-    font-size: 0.8em;
+    font-size: 0.75em;
+    white-space: nowrap;
 }
 
 
@@ -254,13 +261,15 @@
     transform: translate(-50%, -50%);
     text-align: center;
     pointer-events: none;
+    line-height: 1.1;
 }
 
 .location-value .net-dmg {
     display: block;
-    font-size: 0.75em;
+    font-size: 1em;
     font-weight: bold;
     color: #a52a2a;
+    white-space: nowrap;
 }
 
 .location-value.head { top: 13%; left: 50%; }
@@ -278,12 +287,14 @@
     transform: translate(-50%, -50%);
     text-align: center;
     pointer-events: none;
+    line-height: 1.1;
 }
 .hit-location-selector .location-value .net-dmg {
     display: block;
-    font-size: 0.75em;
+    font-size: 1em;
     font-weight: bold;
     color: #a52a2a;
+    white-space: nowrap;
 }
 .hit-location-selector .location-value.head { top: 12%; left: 50%; }
 .hit-location-selector .location-value.torso { top: 34%; left: 50%; }

--- a/templates/dialogs/hit-location-selector.hbs
+++ b/templates/dialogs/hit-location-selector.hbs
@@ -9,10 +9,6 @@
             </div>
             {{/if}}
         </div>
-        <div class="defender-info">
-            <img src="{{defenderImg}}" alt="{{defenderName}}">
-            <span class="defender-name">{{defenderName}}</span>
-        </div>
     </div>
 
     <div class="hit-location-phase attacker-phase" style="display: none;">
@@ -21,14 +17,14 @@
                 <p>Net Hits: <strong id="net-hits-remaining">{{netHits}}</strong></p>
                 <button class="undo-move-btn" disabled>Undo Last Move</button>
             </div>
-            <div class="defender-info">
-                <img src="{{defenderImg}}" alt="{{defenderName}}">
-                <span class="defender-name">{{defenderName}}</span>
-            </div>
         </div>
     </div>
 
     <div class="hit-location-body">
+        <div class="defender-info">
+            <img src="{{defenderImg}}" alt="{{defenderName}}">
+            <span class="defender-name">{{defenderName}}</span>
+        </div>
         <!-- Body Silhouette -->
         <div class="body-outline">
             <svg viewBox="0 0 200 280" xmlns="http://www.w3.org/2000/svg">
@@ -64,34 +60,34 @@
         <div class="values-layer">
             <div class="location-value head" data-location="head">
                 <span class="soak">{{locations.head.soak}}</span>(<span class="armor">{{locations.head.armor}}</span>)
-                <span class="net-dmg">Net Dmg: {{locations.head.net}}</span>
+                <span class="net-dmg">{{locations.head.net}}</span>
             </div>
             <div class="location-value torso" data-location="torso">
                 <span class="soak">{{locations.torso.soak}}</span>(<span class="armor">{{locations.torso.armor}}</span>)
-                <span class="net-dmg">Net Dmg: {{locations.torso.net}}</span>
+                <span class="net-dmg">{{locations.torso.net}}</span>
             </div>
             <div class="location-value left-arm" data-location="left-arm">
                 {{#with (lookup locations 'left-arm') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                <span class="net-dmg">Net Dmg: {{loc.net}}</span>
+                <span class="net-dmg">{{loc.net}}</span>
                 {{/with}}
             </div>
             <div class="location-value right-arm" data-location="right-arm">
                 {{#with (lookup locations 'right-arm') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                <span class="net-dmg">Net Dmg: {{loc.net}}</span>
+                <span class="net-dmg">{{loc.net}}</span>
                 {{/with}}
             </div>
             <div class="location-value left-leg" data-location="left-leg">
                 {{#with (lookup locations 'left-leg') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                <span class="net-dmg">Net Dmg: {{loc.net}}</span>
+                <span class="net-dmg">{{loc.net}}</span>
                 {{/with}}
             </div>
             <div class="location-value right-leg" data-location="right-leg">
                 {{#with (lookup locations 'right-leg') as |loc|}}
                 <span class="soak">{{loc.soak}}</span>(<span class="armor">{{loc.armor}}</span>)
-                <span class="net-dmg">Net Dmg: {{loc.net}}</span>
+                <span class="net-dmg">{{loc.net}}</span>
                 {{/with}}
             </div>
         </div>


### PR DESCRIPTION
## Summary
- overlay defender image and name directly on the hit location body
- enlarge net damage text to match limb labels
- rely on script to add the "Net Dmg:" prefix
- refine overlay style to avoid wrapping and reduce clutter

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6842387ed068832d8020991a0c4afdc4