### PR TITLE
Update HUD overlay and damage text

### DIFF
--- a/styles/hit-location-hud.css
+++ b/styles/hit-location-hud.css
@@ -81,3 +81,29 @@
   top: 50%;
   transform: translateY(-50%);
 }
+
+/* Defender image and name overlay */
+.defender-info {
+  text-align: center;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.hit-hud .defender-info {
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin: 5px;
+  pointer-events: none;
+}
+
+.defender-info img {
+  width: 50px;
+  height: 50px;
+  border: 1px solid #000;
+}
+
+.defender-info .defender-name {
+  font-size: 0.8em;
+}

--- a/styles/hit-location.css
+++ b/styles/hit-location.css
@@ -260,7 +260,7 @@
 
 .location-value .net-dmg {
     display: block;
-    font-size: 1em;
+    font-size: 1rem;
     font-weight: bold;
     color: #a52a2a;
 }
@@ -283,7 +283,7 @@
 }
 .hit-location-selector .location-value .net-dmg {
     display: block;
-    font-size: 1em;
+    font-size: 1rem;
     font-weight: bold;
     color: #a52a2a;
 }

--- a/templates/hud/hit-location-hud.hbs
+++ b/templates/hud/hit-location-hud.hbs
@@ -1,6 +1,10 @@
 {{#if actor}}
 <div class="hud-inner">
   <div class="body-container">
+    <div class="defender-info">
+      <img src="{{actor.img}}" alt="{{actor.name}}">
+      <span class="defender-name">{{actor.name}}</span>
+    </div>
     <div class="layer background-layer">
       <svg viewBox="0 0 200 280" xmlns="http://www.w3.org/2000/svg">
         <path d="M100,50 C120,50 120,60 120,70 L120,110 C120,130 110,140 100,150 C90,140 80,130 80,110 L80,70 C80,60 80,50 100,50Z" fill="#693731" />


### PR DESCRIPTION
## Summary
- display defender info over the hit location HUD
- style the HUD overlay for token image and name
- enlarge net damage preview text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842535ab464832d8e961dbc0607d069