### PR TITLE
Adjust hit location dialog

### DIFF
--- a/styles/hit-location.css
+++ b/styles/hit-location.css
@@ -109,7 +109,7 @@
     margin-bottom: 3px;
 }
 
-/* Net hits display */
+/* Net hits display (used in chat cards) */
 .net-hits-display {
     display: flex;
     align-items: center;
@@ -126,25 +126,30 @@
     color: #000;
 }
 
-.undo-move-btn {
-    padding: 2px 10px;
-    background: #323232;
-    color: var(--color-highlight);
-    border: 1px solid var(--color-text-muted);
+/* Net hits overlay */
+.net-hits-info {
+    position: absolute;
+    top: 0;
+    left: 0;
+    margin: 5px;
+    background: rgba(0, 0, 0, 0.4);
+    padding: 3px;
     border-radius: 3px;
-    cursor: pointer;
-    transition: background-color 0.2s, transform 0.1s;
-    font-size: 0.8em;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 3px;
+    color: #fff;
 }
 
-.undo-move-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
+.net-hits-info p {
+    margin: 0;
+    font-size: 0.75em;
 }
 
-.undo-move-btn:hover:not(:disabled) {
-    background: rgba(70, 70, 70, 0.9);
-    transform: translateY(-1px);
+.net-hits-info #net-hits-remaining {
+    font-size: 1.2em;
+    color: #fff;
 }
 
 .move-cost {

--- a/templates/dialogs/hit-location-selector.hbs
+++ b/templates/dialogs/hit-location-selector.hbs
@@ -16,6 +16,10 @@
             <img src="{{defenderImg}}" alt="{{defenderName}}">
             <span class="defender-name">{{defenderName}}</span>
         </div>
+        <div class="net-hits-info attacker-phase" style="display: none;">
+            <p>Net Hits:</p>
+            <strong id="net-hits-remaining">{{netHits}}</strong>
+        </div>
         <!-- Body Silhouette -->
         <div class="body-outline">
             <svg viewBox="0 0 200 280" xmlns="http://www.w3.org/2000/svg">
@@ -98,15 +102,6 @@
     
     <div class="instruction-text attacker-phase" style="display: none;">
         <p class="compact-instructions">Selected: <strong id="selected-location">None</strong> <span class="move-cost">(Moving costs 2 net hits per adjacent location)</span></p>
-    </div>
-
-        <div class="hit-location-phase attacker-phase" style="display: none;">
-        <div class="compact-info">
-            <div class="net-hits-display">
-                <p>Net Hits: <strong id="net-hits-remaining">{{netHits}}</strong></p>
-                <button class="undo-move-btn" disabled>Undo Last Move</button>
-            </div>
-        </div>
     </div>
     
     <div class="dialog-buttons defender-buttons">


### PR DESCRIPTION
## Summary
- remove undo button from hit location dialog
- support auto-undo by clicking the previous limb
- overlay net hits box beside the defender image
- keep styles for chat card net hits

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68425d65331c832d8bc3b8a0595f9fbe