### PR TITLE
Adjust hit location HUD placement

### DIFF
--- a/scripts/hit-location-hud.js
+++ b/scripts/hit-location-hud.js
@@ -78,8 +78,8 @@ export class HitLocationHUD {
     this.container.id = 'hit-location-hud';
     this.container.classList.add('hit-hud');
     const uiLeft = document.getElementById('ui-left');
-    if (uiLeft) uiLeft.appendChild(this.container);
-    else document.body.appendChild(this.container);
+    if (uiLeft) uiLeft.prepend(this.container);
+    else document.body.prepend(this.container);
 
     this.currentActor = null;
 


### PR DESCRIPTION
## Summary
- ensure Hit Location HUD sits at the top of the player UI by prepending

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68426ab4be5c832da5dccfc9ac966c33