### PR TITLE
Adjust hit location HUD placement

### DIFF
--- a/scripts/hit-location-hud.js
+++ b/scripts/hit-location-hud.js
@@ -78,26 +78,30 @@ export class HitLocationHUD {
     this.container.id = 'hit-location-hud';
     this.container.classList.add('hit-hud');
     const uiLeft = document.getElementById('ui-left');
-    if (uiLeft) uiLeft.appendChild(this.container);
-    else document.body.appendChild(this.container);
+    if (uiLeft) {
+      const controls = uiLeft.querySelector('#controls');
+      if (controls) controls.insertAdjacentElement('afterend', this.container);
+      else uiLeft.appendChild(this.container);
+    } else {
+      document.body.appendChild(this.container);
+    }
 
     this.currentActor = null;
+    this.multiActors = [];
 
-    Hooks.on('controlToken', (token, controlled) => {
-      if (controlled && token.actor?.isOwner) {
-        this.currentActor = token.actor;
-        this.render(token.actor);
-        return;
+    this.container.addEventListener('click', ev => {
+      const card = ev.target.closest('.actor-card');
+      if (!card) return;
+      const id = card.dataset.actorId;
+      const actor = this.multiActors.find(a => a.id === id);
+      if (actor) {
+        this.currentActor = actor;
+        this.render(actor);
       }
+    });
 
-      const owned = canvas.tokens.controlled.filter(t => t.actor?.isOwner);
-      if (owned.length > 0) {
-        this.currentActor = owned[owned.length - 1].actor;
-        this.render(this.currentActor);
-      } else {
-        this.currentActor = null;
-        this.clear();
-      }
+    Hooks.on('controlToken', () => {
+      this.updateFromSelection();
     });
 
     Hooks.on('updateActor', (actor) => {
@@ -111,6 +115,29 @@ export class HitLocationHUD {
         this.render(this.currentActor);
       }
     });
+
+    this.updateFromSelection();
+  }
+
+  static updateFromSelection() {
+    const owned = canvas?.tokens?.controlled.filter(t => t.actor?.isOwner) || [];
+    if (owned.length > 0) {
+      this.multiActors = owned.map(t => t.actor);
+      if (!this.currentActor || !owned.some(t => t.actor?.id === this.currentActor.id)) {
+        this.currentActor = this.multiActors[this.multiActors.length - 1];
+      }
+      this.render(this.currentActor);
+    } else {
+      this.multiActors = [];
+      const playerActor = game.user?.character;
+      if (playerActor) {
+        this.currentActor = playerActor;
+        this.render(playerActor);
+      } else {
+        this.currentActor = null;
+        this.clear();
+      }
+    }
   }
 
   static clear() {
@@ -118,7 +145,10 @@ export class HitLocationHUD {
   }
 
   static async render(actor) {
-    if (!this.container || !actor) return;
+    if (!this.container || !actor) {
+      this.clear();
+      return;
+    }
 
     const anatomy = actor.system?.anatomy || {};
     const trauma = actor.system?.conditions?.trauma || {};
@@ -169,7 +199,11 @@ export class HitLocationHUD {
       }
     }
 
-    const data = { actor, anatomy, trauma, conditions, soakTooltips, traumaTooltips };
+    const selectorData = this.multiActors.length > 1
+      ? this.multiActors.map(a => ({ id: a.id, name: a.name }))
+      : null;
+
+    const data = { actor, selectors: selectorData, anatomy, trauma, conditions, soakTooltips, traumaTooltips };
     const html = await renderTemplate('systems/witch-iron/templates/hud/hit-location-hud.hbs', data);
     this.container.innerHTML = html;
   }

--- a/styles/hit-location-hud.css
+++ b/styles/hit-location-hud.css
@@ -82,3 +82,25 @@
   top: 50%;
   transform: translateY(-50%);
 }
+
+/* Actor selection hand */
+.actor-hand {
+  display: flex;
+  gap: .25rem;
+  justify-content: center;
+  margin-bottom: .25rem;
+}
+
+.actor-card {
+  background: var(--color-border-dark);
+  color: #fff;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.actor-card.active {
+  background: var(--color-accent);
+}

--- a/templates/hud/hit-location-hud.hbs
+++ b/templates/hud/hit-location-hud.hbs
@@ -1,4 +1,11 @@
 {{#if actor}}
+  {{#if selectors}}
+  <div class="actor-hand">
+    {{#each selectors}}
+      <div class="actor-card{{#eq ../actor.id id}} active{{/eq}}" data-actor-id="{{id}}">{{name}}</div>
+    {{/each}}
+  </div>
+  {{/if}}
 <div class="hud-inner">
   <div class="body-container">
     <div class="layer background-layer">


### PR DESCRIPTION
## Summary
- ensure Hit Location HUD is inserted below toolbar and above player list
- default HUD to your assigned actor when no tokens are selected
- add slim selector bar when multiple tokens are controlled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68426ab4be5c832da5dccfc9ac966c33