### PR TITLE
Add weapon list to monster sheet

### DIFF
--- a/scripts/monster-sheet.js
+++ b/scripts/monster-sheet.js
@@ -320,6 +320,11 @@ export class WitchIronMonsterSheet extends ActorSheet {
     
     // Add items categorized by type
     context.injuries = actorData.items.filter(item => item.type === 'injury');
+    context.weapons = actorData.items.filter(item => item.type === 'weapon');
+
+    // Label for the default monster weapon based on configured weapon types
+    const wtKey = system.stats.weaponType?.value || 'unarmed';
+    context.defaultWeaponLabel = context.weaponTypes?.[wtKey] || wtKey;
 
     // Hit location data for soak display
     const anatomy = this.actor.system.anatomy || {};
@@ -374,6 +379,8 @@ export class WitchIronMonsterSheet extends ActorSheet {
     
     // Monster action buttons
     html.find('.monster-action.melee-attack').click(this._onMeleeAttack.bind(this));
+    html.find('.monster-action.weapon-attack').click(this._onWeaponAttack.bind(this));
+    html.find('.create-weapon').click(this._onItemCreate.bind(this));
     html.find('.monster-action.specialized-roll').click(this._rollSpecializedCheck.bind(this));
     
     // Battle wear buttons
@@ -923,6 +930,21 @@ export class WitchIronMonsterSheet extends ActorSheet {
         isCombatCheck: true,
         additionalHits: opts.additionalHits
       });
+    }
+  }
+
+  /**
+   * Handle attack with an item weapon
+   * @param {Event} event The originating click event
+   * @private
+   */
+  async _onWeaponAttack(event) {
+    event.preventDefault();
+    const li = event.currentTarget.closest(".item");
+    if (!li) return;
+    const item = this.actor.items.get(li.dataset.itemId);
+    if (item && typeof item.roll === "function") {
+      await item.roll();
     }
   }
 

--- a/styles/witch-iron.css
+++ b/styles/witch-iron.css
@@ -3448,6 +3448,40 @@ button.roll-skill:hover {
   box-shadow: 0 0 5px #f0a890;
 }
 
+/* Monster Weapons List */
+.monster-weapons-list {
+  margin: 10px 0;
+  padding: 0 10px;
+}
+
+.monster-weapons-list .items-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.monster-weapons-list .item {
+  display: flex;
+  align-items: center;
+  padding: 4px 0;
+  border-bottom: 1px solid var(--color-border-lighter);
+}
+
+.monster-weapons-list .weapon-name {
+  flex: 1;
+  padding-right: 5px;
+}
+
+.monster-weapons-list .item-controls {
+  display: flex;
+  gap: 5px;
+}
+
+.monster-weapons-list .item-create {
+  margin-top: 8px;
+  text-align: center;
+}
+
 /* Injury severity colors */
 .injuries-list .severity-minor {
   color: #3a7828;

--- a/templates/actors/monster-sheet.hbs
+++ b/templates/actors/monster-sheet.hbs
@@ -141,13 +141,35 @@
 
             <div class="monster-actions-section">
                 <h2>Monster Actions</h2>
-                <div class="monster-actions grid grid-2col">
-                    <button type="button" class="monster-action melee-attack">
-                        <i class="fas fa-fist-raised"></i> Melee Attack
-                    </button>
-                    <button type="button" class="monster-action specialized-roll">
-                        <i class="fas fa-dice-d20"></i> Specialized Roll
-                    </button>
+                <div class="monster-weapons-list">
+                  <ol class="items-list">
+                    <li class="item default-weapon">
+                      <span class="weapon-name">{{defaultWeaponLabel}}</span>
+                      <div class="item-controls">
+                        <button type="button" class="monster-action melee-attack">
+                          <i class="fas fa-fist-raised"></i> Attack
+                        </button>
+                      </div>
+                    </li>
+                    {{#each weapons as |weapon id|}}
+                    <li class="item" data-item-id="{{weapon._id}}">
+                      <span class="weapon-name">{{weapon.name}}</span>
+                      <div class="item-controls">
+                        <button type="button" class="monster-action weapon-attack"><i class="fas fa-crosshairs"></i></button>
+                        <a class="item-control item-edit" title="Edit Weapon"><i class="fas fa-edit"></i></a>
+                        <a class="item-control item-delete" title="Delete Weapon"><i class="fas fa-trash"></i></a>
+                      </div>
+                    </li>
+                    {{/each}}
+                  </ol>
+                  <div class="item-create" data-type="weapon">
+                    <button type="button" class="create-weapon" data-type="weapon"><i class="fas fa-plus"></i> Add Weapon</button>
+                  </div>
+                </div>
+                <div class="monster-actions">
+                  <button type="button" class="monster-action specialized-roll">
+                      <i class="fas fa-dice-d20"></i> Specialized Roll
+                  </button>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- replace melee attack button with a weapon list
- add handler for item weapon attacks
- expose default weapon label in sheet data
- style new monster weapon list

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68431c7c0474832d846496a863f42184