### PR TITLE
Update descendant sheet

### DIFF
--- a/scripts/descendant-sheet.js
+++ b/scripts/descendant-sheet.js
@@ -22,6 +22,18 @@ export class WitchIronDescendantSheet extends ActorSheet {
   }
 
   /** @override */
+  async _render(force = false, options = {}) {
+    const result = await super._render(force, options);
+    const uiRight = document.getElementById("ui-right");
+    const rightWidth = uiRight ? uiRight.offsetWidth : 0;
+    const maxLeft = window.innerWidth - rightWidth - this.position.width - 10;
+    if (this.position.left > maxLeft) {
+      this.setPosition({ left: Math.max(maxLeft, 100) });
+    }
+    return result;
+  }
+
+  /** @override */
   getData() {
     console.log("WitchIronDescendantSheet | Getting sheet data");
     // Retrieve the base data from the parent method
@@ -41,6 +53,72 @@ export class WitchIronDescendantSheet extends ActorSheet {
 
     // Prepare items
     this._prepareItems(data);
+
+    // Prepare injuries list
+    data.injuries = data.actor.items.filter(it => it.type === 'injury');
+
+    // Prepare conditions
+    data.conditions = {};
+    data.currentConditions = [];
+    data.zeroConditions = [];
+    const conditionsData = data.system.conditions || {};
+    for (const condKey in conditionsData) {
+      if (condKey === 'trauma' && typeof conditionsData.trauma === 'object') {
+        for (const loc in conditionsData.trauma) {
+          const key = `trauma.${loc}`;
+          const labelLoc = loc.replace(/([A-Z])/g, ' $1');
+          const value = conditionsData.trauma[loc].value;
+          const condObj = { key, label: `Trauma (${labelLoc.charAt(0).toUpperCase() + labelLoc.slice(1)})`, value };
+          data.conditions[key] = condObj;
+          (value > 0 ? data.currentConditions : data.zeroConditions).push(condObj);
+        }
+      } else {
+        const value = conditionsData[condKey].value;
+        const label = condKey.charAt(0).toUpperCase() + condKey.slice(1);
+        const condObj = { key: condKey, label, value };
+        data.conditions[condKey] = condObj;
+        (value > 0 ? data.currentConditions : data.zeroConditions).push(condObj);
+      }
+    }
+
+    // HUD condition icons
+    const hudConditions = [];
+    for (const [key, d] of Object.entries(conditionsData)) {
+      if (key === 'trauma') continue;
+      const val = Number(d?.value || 0);
+      if (val >= 1) {
+        hudConditions.push({ key, value: val, faIcon: 'fa-exclamation-circle', tooltip: `${key} ${val}` });
+      }
+    }
+    hudConditions.sort((a,b) => a.key.localeCompare(b.key));
+    data.hudConditions = hudConditions;
+
+    // Hit location data for soak display
+    const anatomy = data.system.anatomy || {};
+    const trauma = data.system.conditions?.trauma || {};
+    const rb = Number(data.system.attributes?.robustness?.bonus || 0);
+    const LOCS = ["head","torso","leftArm","rightArm","leftLeg","rightLeg"];
+    const soakTooltips = {};
+    const traumaTooltips = {};
+    for (const loc of LOCS) {
+      const wearVal = Number(data.system.battleWear?.armor?.[loc]?.value || 0);
+      const locData = anatomy[loc] || {};
+      const soak = Number(locData.soak || 0);
+      const av = Number(locData.armor || 0);
+      const other = soak - rb - (av - wearVal);
+      const otherVal = other > 0 ? other : 0;
+      soakTooltips[loc] = `${rb} + ${otherVal} + (${av} - ${wearVal}) = ${soak}`;
+
+      const rating = Number(trauma[loc]?.value || 0);
+      if (rating > 0) {
+        const locLabel = loc.replace(/([A-Z])/g, ' $1').replace(/^./, c => c.toUpperCase());
+        traumaTooltips[loc] = `Trauma (${locLabel}) ${rating}: ${rating * 20}% penalty to checks involving ${locLabel}.`;
+      }
+    }
+    data.anatomy = anatomy;
+    data.trauma = trauma;
+    data.soakTooltips = soakTooltips;
+    data.traumaTooltips = traumaTooltips;
 
     // Return data for rendering
     return data;
@@ -119,6 +197,13 @@ export class WitchIronDescendantSheet extends ActorSheet {
       li.slideUp(200, () => this.render(false));
     });
 
+    // Roll item from name
+    html.find('.item-name.item-roll').click(ev => {
+      const li = $(ev.currentTarget).parents('.item');
+      const item = this.actor.items.get(li.data('itemId'));
+      if (item && item.roll) item.roll();
+    });
+
     // Roll Skills by clicking on skill name
     html.find('.roll-skill').click(this._onRollSkill.bind(this));
 
@@ -127,6 +212,16 @@ export class WitchIronDescendantSheet extends ActorSheet {
 
     // Manage Specializations
     html.find('.skill-specialization-button').click(this._onManageSpecializations.bind(this));
+
+    // Battle wear buttons
+    html.find('.battle-wear-plus').click(this._onBattleWearPlus.bind(this));
+    html.find('.battle-wear-minus').click(this._onBattleWearMinus.bind(this));
+    html.find('.battle-wear-reset').click(this._onBattleWearReset.bind(this));
+
+    // Condition controls
+    html.find('.cond-plus').click(this._onConditionPlus.bind(this));
+    html.find('.cond-minus').click(this._onConditionMinus.bind(this));
+    html.find('.cond-value').change(this._onConditionInput.bind(this));
 
     // Toggle specializations visibility when clicking on skill name
     html.find('.skill-name').click(ev => {
@@ -597,5 +692,129 @@ export class WitchIronDescendantSheet extends ActorSheet {
       console.error("Error resetting skills:", error);
       ui.notifications.error("Failed to initialize skills structure. See console for details.");
     }
+  }
+
+  async _onBattleWearPlus(event) {
+    event.preventDefault();
+    const type = event.currentTarget.dataset.type;
+    const locs = ["head","torso","leftArm","rightArm","leftLeg","rightLeg"];
+    let current = 0; let max = 0; let path = "";
+    if (type === 'weapon') {
+      current = this.actor.system.battleWear?.weapon?.value || 0;
+      max = this.actor.system.derived?.weaponBonusMax || 0;
+      path = 'system.battleWear.weapon.value';
+    } else if (type && type.startsWith('armor-')) {
+      const loc = type.split('-')[1];
+      if (locs.includes(loc)) {
+        current = this.actor.system.battleWear?.armor?.[loc]?.value || 0;
+        max = this.actor.system.derived?.armorBonusMax || 0;
+        path = `system.battleWear.armor.${loc}.value`;
+      }
+    }
+    if (current >= max) return;
+    const update = {}; update[path] = current + 1;
+    await this.actor.update(update);
+    this._updateBattleWearDisplays();
+  }
+
+  async _onBattleWearMinus(event) {
+    event.preventDefault();
+    const type = event.currentTarget.dataset.type;
+    const locs = ["head","torso","leftArm","rightArm","leftLeg","rightLeg"];
+    let current = 0; let path = "";
+    if (type === 'weapon') {
+      current = this.actor.system.battleWear?.weapon?.value || 0;
+      path = 'system.battleWear.weapon.value';
+    } else if (type && type.startsWith('armor-')) {
+      const loc = type.split('-')[1];
+      if (locs.includes(loc)) {
+        current = this.actor.system.battleWear?.armor?.[loc]?.value || 0;
+        path = `system.battleWear.armor.${loc}.value`;
+      }
+    }
+    if (current <= 0) return;
+    const update = {}; update[path] = current - 1;
+    await this.actor.update(update);
+    this._updateBattleWearDisplays();
+  }
+
+  async _onBattleWearReset(event) {
+    event.preventDefault();
+    const type = event.currentTarget.dataset.type;
+    const locs = ["head","torso","leftArm","rightArm","leftLeg","rightLeg"];
+    let current = 0; let path = "";
+    if (type === 'weapon') {
+      current = this.actor.system.battleWear?.weapon?.value || 0;
+      path = 'system.battleWear.weapon.value';
+    } else if (type && type.startsWith('armor-')) {
+      const loc = type.split('-')[1];
+      if (locs.includes(loc)) {
+        current = this.actor.system.battleWear?.armor?.[loc]?.value || 0;
+        path = `system.battleWear.armor.${loc}.value`;
+      }
+    }
+    if (current <= 0) return;
+    const update = {}; update[path] = 0;
+    await this.actor.update(update);
+    this._updateBattleWearDisplays();
+  }
+
+  _updateBattleWearDisplays() {
+    const html = this.element;
+    if (!html || !html.length) return;
+    const actorData = this.actor.system;
+    const armorLocs = ["head","torso","leftArm","rightArm","leftLeg","rightLeg"];
+    html.find('.battle-wear-value[data-type="weapon"]').text(actorData.battleWear?.weapon?.value || 0);
+    for (const loc of armorLocs) {
+      html.find(`.battle-wear-value[data-type="armor-${loc}"]`).text(actorData.battleWear?.armor?.[loc]?.value || 0);
+    }
+    this._updateBattleWearButtonStates();
+  }
+
+  _updateBattleWearButtonStates() {
+    const weaponMax = this.actor.system.derived?.weaponBonusMax || 0;
+    const armorMax = this.actor.system.derived?.armorBonusMax || 0;
+    const armorLocs = ["head","torso","leftArm","rightArm","leftLeg","rightLeg"];
+    const weaponVal = this.actor.system.battleWear?.weapon?.value || 0;
+    this.element.find('.battle-wear-plus[data-type="weapon"]').prop('disabled', weaponVal >= weaponMax);
+    this.element.find('.battle-wear-minus[data-type="weapon"]').prop('disabled', weaponVal <= 0);
+    for (const loc of armorLocs) {
+      const val = this.actor.system.battleWear?.armor?.[loc]?.value || 0;
+      this.element.find(`.battle-wear-plus[data-type="armor-${loc}"]`).prop('disabled', val >= armorMax);
+      this.element.find(`.battle-wear-minus[data-type="armor-${loc}"]`).prop('disabled', val <= 0);
+    }
+  }
+
+  async _onConditionPlus(event) {
+    event.preventDefault();
+    const row = event.currentTarget.closest('.condition-row');
+    const cond = row.dataset.condition;
+    const input = row.querySelector('input.cond-value');
+    let value = parseInt(input?.value) || foundry.utils.getProperty(this.actor, `system.conditions.${cond}.value`) || 0;
+    value = value + 1;
+    if (input) input.value = value;
+    await this.actor.update({ [`system.conditions.${cond}.value`]: value });
+  }
+
+  async _onConditionMinus(event) {
+    event.preventDefault();
+    const row = event.currentTarget.closest('.condition-row');
+    const cond = row.dataset.condition;
+    const input = row.querySelector('input.cond-value');
+    let value = parseInt(input?.value) || foundry.utils.getProperty(this.actor, `system.conditions.${cond}.value`) || 0;
+    value = Math.max(0, value - 1);
+    if (input) input.value = value;
+    await this.actor.update({ [`system.conditions.${cond}.value`]: value });
+  }
+
+  async _onConditionInput(event) {
+    event.preventDefault();
+    const input = event.currentTarget;
+    const row = input.closest('.condition-row');
+    const cond = row.dataset.condition;
+    let value = parseInt(input.value) || 0;
+    value = Math.max(0, value);
+    input.value = value;
+    await this.actor.update({ [`system.conditions.${cond}.value`]: value });
   }
 } 

--- a/styles/witch-iron.css
+++ b/styles/witch-iron.css
@@ -3469,17 +3469,20 @@ button.roll-skill:hover {
 }
 
 /* Battle Wear Controls */
-.witch-iron.sheet.monster .battle-wear-controls {
+.witch-iron.sheet.monster .battle-wear-controls,
+.witch-iron.sheet.descendant .battle-wear-controls {
   margin-bottom: 10px;
 }
 
-.witch-iron.sheet.monster .battle-wear-control {
+.witch-iron.sheet.monster .battle-wear-control,
+.witch-iron.sheet.descendant .battle-wear-control {
   display: flex;
   align-items: center;
   margin-top: 5px;
 }
 
-.witch-iron.sheet.monster .battle-wear-value {
+.witch-iron.sheet.monster .battle-wear-value,
+.witch-iron.sheet.descendant .battle-wear-value {
   display: inline-block;
   font-size: 1.2em;
   font-weight: bold;
@@ -3498,7 +3501,10 @@ button.roll-skill:hover {
 
 .witch-iron.sheet.monster .battle-wear-minus,
 .witch-iron.sheet.monster .battle-wear-plus,
-.witch-iron.sheet.monster .battle-wear-reset {
+.witch-iron.sheet.monster .battle-wear-reset,
+.witch-iron.sheet.descendant .battle-wear-minus,
+.witch-iron.sheet.descendant .battle-wear-plus,
+.witch-iron.sheet.descendant .battle-wear-reset {
   width: 32px;
   height: 32px;
   padding: 0;
@@ -3511,24 +3517,30 @@ button.roll-skill:hover {
   transition: all 0.2s ease;
 }
 
-.witch-iron.sheet.monster .battle-wear-reset {
+.witch-iron.sheet.monster .battle-wear-reset,
+.witch-iron.sheet.descendant .battle-wear-reset {
   margin-left: 8px;
   background-color: var(--secondary-color);
   color: #fff;
 }
 
 .witch-iron.sheet.monster .battle-wear-minus:hover,
-.witch-iron.sheet.monster .battle-wear-plus:hover {
+.witch-iron.sheet.monster .battle-wear-plus:hover,
+.witch-iron.sheet.descendant .battle-wear-minus:hover,
+.witch-iron.sheet.descendant .battle-wear-plus:hover {
   background-color: var(--highlight-color);
   color: #fff;
 }
 
-.witch-iron.sheet.monster .battle-wear-reset:hover {
+.witch-iron.sheet.monster .battle-wear-reset:hover,
+.witch-iron.sheet.descendant .battle-wear-reset:hover {
   background-color: var(--accent-color);
 }
 
 .witch-iron.sheet.monster .battle-wear-minus:disabled,
-.witch-iron.sheet.monster .battle-wear-plus:disabled {
+.witch-iron.sheet.monster .battle-wear-plus:disabled,
+.witch-iron.sheet.descendant .battle-wear-minus:disabled,
+.witch-iron.sheet.descendant .battle-wear-plus:disabled {
   opacity: 0.5;
   cursor: not-allowed;
   background-color: var(--color-border-light);
@@ -3787,13 +3799,15 @@ button.roll-skill:hover {
 }
 
 /* Hit location wear layout on monster sheet */
-.witch-iron.sheet.monster .hit-hud {
+.witch-iron.sheet.monster .hit-hud,
+.witch-iron.sheet.descendant .hit-hud {
   width: 360px;
   max-width: 360px;
   margin: 0 auto 10px;
 }
 
-.witch-iron.sheet.monster .hit-hud .wear-controls {
+.witch-iron.sheet.monster .hit-hud .wear-controls,
+.witch-iron.sheet.descendant .hit-hud .wear-controls {
   margin-top: 2px;
   display: flex;
   justify-content: center;
@@ -3803,7 +3817,9 @@ button.roll-skill:hover {
 }
 
 .witch-iron.sheet.monster .hit-hud .battle-wear-minus,
-.witch-iron.sheet.monster .hit-hud .battle-wear-plus {
+.witch-iron.sheet.monster .hit-hud .battle-wear-plus,
+.witch-iron.sheet.descendant .hit-hud .battle-wear-minus,
+.witch-iron.sheet.descendant .hit-hud .battle-wear-plus {
   width: 16px;
   height: 16px;
   font-size: 10px;
@@ -3811,18 +3827,21 @@ button.roll-skill:hover {
   line-height: 1;
 }
 
-.witch-iron.sheet.monster .hit-hud .battle-wear-value {
+.witch-iron.sheet.monster .hit-hud .battle-wear-value,
+.witch-iron.sheet.descendant .hit-hud .battle-wear-value {
   width: 20px;
   font-size: 0.75rem;
   line-height: 1;
   padding: 0 2px;
 }
 
-.witch-iron.sheet.monster .hit-hud .wear-max {
+.witch-iron.sheet.monster .hit-hud .wear-max,
+.witch-iron.sheet.descendant .hit-hud .wear-max {
   font-size: 0.65rem;
 }
 
-.witch-iron.sheet.monster .weapon-wear-container {
+.witch-iron.sheet.monster .weapon-wear-container,
+.witch-iron.sheet.descendant .weapon-wear-container {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -3830,18 +3849,21 @@ button.roll-skill:hover {
   margin-top: 6px;
 }
 
-.witch-iron.sheet.monster .battle-wear-heading {
+.witch-iron.sheet.monster .battle-wear-heading,
+.witch-iron.sheet.descendant .battle-wear-heading {
   text-align: center;
   margin: 0 0 6px;
   font-size: 1.2rem;
   color: var(--color-primary);
 }
 
-.witch-iron.sheet.monster .weapon-wear-label {
+.witch-iron.sheet.monster .weapon-wear-label,
+.witch-iron.sheet.descendant .weapon-wear-label {
   font-weight: bold;
 }
 
-.witch-iron.sheet.monster .hit-hud .wear-label {
+.witch-iron.sheet.monster .hit-hud .wear-label,
+.witch-iron.sheet.descendant .hit-hud .wear-label {
   position: absolute;
   top: 0;
   left: 0;
@@ -3853,24 +3875,29 @@ button.roll-skill:hover {
 }
 
 .witch-iron.sheet.monster .weapon-wear-container .battle-wear-minus,
-.witch-iron.sheet.monster .weapon-wear-container .battle-wear-plus {
+.witch-iron.sheet.monster .weapon-wear-container .battle-wear-plus,
+.witch-iron.sheet.descendant .weapon-wear-container .battle-wear-minus,
+.witch-iron.sheet.descendant .weapon-wear-container .battle-wear-plus {
   width: 18px;
   height: 18px;
   padding: 0;
   line-height: 1;
 }
 
-.witch-iron.sheet.monster .weapon-wear-container .battle-wear-value {
+.witch-iron.sheet.monster .weapon-wear-container .battle-wear-value,
+.witch-iron.sheet.descendant .weapon-wear-container .battle-wear-value {
   width: 25px;
   text-align: center;
   font-size: 0.9rem;
 }
 
-.witch-iron.sheet.monster .weapon-wear-container .wear-max {
+.witch-iron.sheet.monster .weapon-wear-container .wear-max,
+.witch-iron.sheet.descendant .weapon-wear-container .wear-max {
   font-size: 0.8rem;
 }
 
-.witch-iron.sheet.monster .conditions-layer {
+.witch-iron.sheet.monster .conditions-layer,
+.witch-iron.sheet.descendant .conditions-layer {
   z-index: 3;
   gap: .15rem;
   flex-direction: column;
@@ -3879,7 +3906,8 @@ button.roll-skill:hover {
   pointer-events: none;
 }
 
-.witch-iron.sheet.monster .condition {
+.witch-iron.sheet.monster .condition,
+.witch-iron.sheet.descendant .condition {
   position: relative;
   background: var(--color-border-dark);
   color: #fff;
@@ -3889,7 +3917,8 @@ button.roll-skill:hover {
   pointer-events: auto;
 }
 
-.witch-iron.sheet.monster .condition i {
+.witch-iron.sheet.monster .condition i,
+.witch-iron.sheet.descendant .condition i {
   position: absolute;
   left: 4px;
   top: 50%;

--- a/templates/actors/descendant-sheet.hbs
+++ b/templates/actors/descendant-sheet.hbs
@@ -39,6 +39,7 @@
     <a class="item" data-tab="equipment">Equipment</a>
     <a class="item" data-tab="character">Character</a>
     <a class="item" data-tab="notes">Notes</a>
+    <a class="item" data-tab="injuries">Injuries</a>
   </nav>
 
   <div class="sheet-content flexrow">
@@ -613,9 +614,9 @@
       <div class="tab equipment" data-group="primary" data-tab="equipment">
         <section class="equipment-container">
           <div class="inventory-list">
-            <!-- Weapons -->
+            <!-- Attacks -->
             <div class="inventory-section">
-              <h2>Weapons <button type="button" class="create-item" data-type="weapon"><i class="fas fa-plus"></i></button></h2>
+              <h2>Attacks <button type="button" class="create-item" data-type="weapon"><i class="fas fa-plus"></i></button></h2>
               <div class="items-list">
                 <div class="inventory-header flexrow">
                   <div class="item-name">Name</div>
@@ -625,7 +626,7 @@
                 </div>
                 {{#each weapons as |item id|}}
                 <div class="item flexrow" data-item-id="{{item._id}}">
-                  <div class="item-name">{{item.name}}</div>
+                  <div class="item-name item-roll">{{item.name}}</div>
                   <div class="item-damage">{{item.system.damage}}</div>
                   <div class="item-weight">{{item.system.encumbrance.value}}</div>
                   <div class="item-controls">
@@ -769,6 +770,165 @@
             <textarea name="system.notes" rows="20">{{system.notes}}</textarea>
           </div>
         </section>
+      </div>
+
+      {{!-- Injuries Tab --}}
+      <div class="tab" data-group="primary" data-tab="injuries">
+        <div class="monster-battlewear">
+          <h2 class="battle-wear-heading">Battle Wear</h2>
+          <div class="weapon-wear-container">
+            <span class="weapon-wear-label"><strong>Weapon Wear</strong></span>
+            <button type="button" class="battle-wear-minus" data-type="weapon"><i class="fas fa-minus"></i></button>
+            <span class="battle-wear-value" data-type="weapon">{{system.battleWear.weapon.value}}</span>/<span class="wear-max">{{system.derived.weaponBonusMax}}</span>
+            <button type="button" class="battle-wear-plus" data-type="weapon"><i class="fas fa-plus"></i></button>
+          </div>
+          <div class="hit-hud monster-wear-layout">
+            <span class="wear-label">Armor Wear</span>
+            <div class="hud-inner">
+              <div class="body-container">
+                <div class="layer background-layer">
+                  <svg viewBox="0 0 200 280" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M100,50 C120,50 120,60 120,70 L120,110 C120,130 110,140 100,150 C90,140 80,130 80,110 L80,70 C80,60 80,50 100,50Z" fill="#693731" />
+                    <circle cx="100" cy="35" r="15" fill="#693731" />
+                    <path d="M80,70 C70,75 55,90 50,110 C45,130 45,140 55,150" stroke="#693731" stroke-width="16" fill="none" />
+                    <path d="M120,70 C130,75 145,90 150,110 C155,130 155,140 145,150" stroke="#693731" stroke-width="16" fill="none" />
+                    <path d="M90,150 C85,170 80,190 75,230" stroke="#693731" stroke-width="15" fill="none" />
+                    <path d="M110,150 C115,170 120,190 125,230" stroke="#693731" stroke-width="15" fill="none" />
+                  </svg>
+                </div>
+                <div class="layer values-layer">
+                  <div class="location-value head" title="{{soakTooltips.head}}">
+                    <span class="soak">{{anatomy.head.soak}}</span>(<span class="armor">{{anatomy.head.armor}}</span>)
+                    {{#if trauma.head.value}}
+                    <span class="trauma" title="{{traumaTooltips.head}}"><i class="fa-solid fa-bone-break"></i> <span class="trauma-value">{{trauma.head.value}}</span></span>
+                    {{/if}}
+                    <div class="wear-controls">
+                      <button type="button" class="battle-wear-minus" data-type="armor-head"><i class="fas fa-minus"></i></button>
+                      <span class="battle-wear-value" data-type="armor-head">{{system.battleWear.armor.head.value}}</span>/<span class="wear-max">{{system.derived.armorBonusMax}}</span>
+                      <button type="button" class="battle-wear-plus" data-type="armor-head"><i class="fas fa-plus"></i></button>
+                    </div>
+                  </div>
+                  <div class="location-value torso" title="{{soakTooltips.torso}}">
+                    <span class="soak">{{anatomy.torso.soak}}</span>(<span class="armor">{{anatomy.torso.armor}}</span>)
+                    {{#if trauma.torso.value}}
+                    <span class="trauma" title="{{traumaTooltips.torso}}"><i class="fa-solid fa-bone-break"></i> <span class="trauma-value">{{trauma.torso.value}}</span></span>
+                    {{/if}}
+                    <div class="wear-controls">
+                      <button type="button" class="battle-wear-minus" data-type="armor-torso"><i class="fas fa-minus"></i></button>
+                      <span class="battle-wear-value" data-type="armor-torso">{{system.battleWear.armor.torso.value}}</span>/<span class="wear-max">{{system.derived.armorBonusMax}}</span>
+                      <button type="button" class="battle-wear-plus" data-type="armor-torso"><i class="fas fa-plus"></i></button>
+                    </div>
+                  </div>
+                  <div class="location-value leftArm" title="{{soakTooltips.leftArm}}">
+                    <span class="soak">{{anatomy.leftArm.soak}}</span>(<span class="armor">{{anatomy.leftArm.armor}}</span>)
+                    {{#if trauma.leftArm.value}}
+                    <span class="trauma" title="{{traumaTooltips.leftArm}}"><i class="fa-solid fa-bone-break"></i> <span class="trauma-value">{{trauma.leftArm.value}}</span></span>
+                    {{/if}}
+                    <div class="wear-controls">
+                      <button type="button" class="battle-wear-minus" data-type="armor-leftArm"><i class="fas fa-minus"></i></button>
+                      <span class="battle-wear-value" data-type="armor-leftArm">{{system.battleWear.armor.leftArm.value}}</span>/<span class="wear-max">{{system.derived.armorBonusMax}}</span>
+                      <button type="button" class="battle-wear-plus" data-type="armor-leftArm"><i class="fas fa-plus"></i></button>
+                    </div>
+                  </div>
+                  <div class="location-value rightArm" title="{{soakTooltips.rightArm}}">
+                    <span class="soak">{{anatomy.rightArm.soak}}</span>(<span class="armor">{{anatomy.rightArm.armor}}</span>)
+                    {{#if trauma.rightArm.value}}
+                    <span class="trauma" title="{{traumaTooltips.rightArm}}"><i class="fa-solid fa-bone-break"></i> <span class="trauma-value">{{trauma.rightArm.value}}</span></span>
+                    {{/if}}
+                    <div class="wear-controls">
+                      <button type="button" class="battle-wear-minus" data-type="armor-rightArm"><i class="fas fa-minus"></i></button>
+                      <span class="battle-wear-value" data-type="armor-rightArm">{{system.battleWear.armor.rightArm.value}}</span>/<span class="wear-max">{{system.derived.armorBonusMax}}</span>
+                      <button type="button" class="battle-wear-plus" data-type="armor-rightArm"><i class="fas fa-plus"></i></button>
+                    </div>
+                  </div>
+                  <div class="location-value leftLeg" title="{{soakTooltips.leftLeg}}">
+                    <span class="soak">{{anatomy.leftLeg.soak}}</span>(<span class="armor">{{anatomy.leftLeg.armor}}</span>)
+                    {{#if trauma.leftLeg.value}}
+                    <span class="trauma" title="{{traumaTooltips.leftLeg}}"><i class="fa-solid fa-bone-break"></i> <span class="trauma-value">{{trauma.leftLeg.value}}</span></span>
+                    {{/if}}
+                    <div class="wear-controls">
+                      <button type="button" class="battle-wear-minus" data-type="armor-leftLeg"><i class="fas fa-minus"></i></button>
+                      <span class="battle-wear-value" data-type="armor-leftLeg">{{system.battleWear.armor.leftLeg.value}}</span>/<span class="wear-max">{{system.derived.armorBonusMax}}</span>
+                      <button type="button" class="battle-wear-plus" data-type="armor-leftLeg"><i class="fas fa-plus"></i></button>
+                    </div>
+                  </div>
+                  <div class="location-value rightLeg" title="{{soakTooltips.rightLeg}}">
+                    <span class="soak">{{anatomy.rightLeg.soak}}</span>(<span class="armor">{{anatomy.rightLeg.armor}}</span>)
+                    {{#if trauma.rightLeg.value}}
+                    <span class="trauma" title="{{traumaTooltips.rightLeg}}"><i class="fa-solid fa-bone-break"></i> <span class="trauma-value">{{trauma.rightLeg.value}}</span></span>
+                    {{/if}}
+                    <div class="wear-controls">
+                      <button type="button" class="battle-wear-minus" data-type="armor-rightLeg"><i class="fas fa-minus"></i></button>
+                      <span class="battle-wear-value" data-type="armor-rightLeg">{{system.battleWear.armor.rightLeg.value}}</span>/<span class="wear-max">{{system.derived.armorBonusMax}}</span>
+                      <button type="button" class="battle-wear-plus" data-type="armor-rightLeg"><i class="fas fa-plus"></i></button>
+                    </div>
+                  </div>
+                </div>
+                <div class="layer conditions-layer">
+                  {{#each hudConditions}}
+                  <div class="condition" title="{{tooltip}}">
+                    <i class="fas {{faIcon}}"></i>
+                    <span class="value">{{value}}</span>
+                  </div>
+                  {{/each}}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="injuries-list">
+          <h2>Injuries</h2>
+          <div class="items-header flexrow">
+            <span class="injury-name">Name</span>
+            <span class="injury-severity">Severity</span>
+            <span class="injury-effect">Effect</span>
+            <span class="item-controls"></span>
+          </div>
+
+          <ol class="items-list">
+            {{#each injuries as |injury id|}}
+            <li class="item flexrow" data-item-id="{{injury._id}}">
+              <div class="injury-name">{{injury.name}}</div>
+              <div class="injury-severity">{{injury.system.severity.value}}</div>
+              <div class="injury-effect">{{injury.system.effect}}</div>
+              <div class="item-controls">
+                <a class="item-control item-edit" title="Edit Injury"><i class="fas fa-edit"></i></a>
+                <a class="item-control item-delete" title="Delete Injury"><i class="fas fa-trash"></i></a>
+              </div>
+            </li>
+            {{/each}}
+          </ol>
+
+          <div class="item-create">
+            <button type="button" class="create-injury" data-type="injury"><i class="fas fa-plus"></i> Add Injury</button>
+          </div>
+          <div class="conditions-list">
+            <h2>Current Conditions</h2>
+            {{#each currentConditions}}
+            <div class="condition-row flexrow" data-condition="{{this.key}}">
+              <button type="button" class="condition-name cond-quarrel">{{this.label}}</button>
+              <button type="button" class="cond-minus"><i class="fas fa-minus"></i></button>
+              <input type="number" class="cond-value" value="{{this.value}}" min="0" />
+              <button type="button" class="cond-plus"><i class="fas fa-plus"></i></button>
+            </div>
+            {{/each}}
+
+            <details class="zero-conditions">
+              <summary class="btn">
+                <i class="fas fa-caret-right toggle-arrow"></i>
+                Other Conditions
+              </summary>
+              {{#each zeroConditions}}
+              <div class="condition-row flexrow" data-condition="{{this.key}}">
+                <button type="button" class="condition-name cond-quarrel">{{this.label}}</button>
+                <button type="button" class="cond-minus"><i class="fas fa-minus"></i></button>
+                <input type="number" class="cond-value" value="{{this.value}}" min="0" />
+                <button type="button" class="cond-plus"><i class="fas fa-plus"></i></button>
+              </div>
+              {{/each}}
+            </details>
+          </div>
+        </div>
       </div>
     </section>
   </div>


### PR DESCRIPTION
## Summary
- rename weapon section to Attacks and make item names rollable
- add Injuries tab with battle wear, hit locations, conditions list
- collect injury and condition data in descendant sheet
- support battle wear and condition controls via JS
- share battle wear CSS with descendant sheet
- **fix descendant sheet hit layout size & window position**

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68431cdd8d70832d958cb222f68a51e6