### PR TITLE
Expand items and conditions

### DIFF
--- a/scripts/actor.js
+++ b/scripts/actor.js
@@ -241,12 +241,35 @@ export class WitchIronActor extends Actor {
     const intellectValue = systemData.attributes.intellect?.value || 0;
     systemData.derivedFlags.canReadWrite = intellectValue >= 40;
 
-    // Initialize common conditions
-    const condList = ["blind", "deaf", "pain"];
+    // Initialize common conditions using the full monster list for consistency
+    const condList = [
+      "poison",
+      "corruption",
+      "stress",
+      "blind",
+      "deaf",
+      "pain",
+      "fatigue",
+      "entangle",
+      "helpless",
+      "stun",
+      "prone"
+    ];
     if (!systemData.conditions) systemData.conditions = {};
     for (const key of condList) {
       if (!systemData.conditions[key] || typeof systemData.conditions[key]?.value !== 'number') {
         systemData.conditions[key] = { value: 0 };
+      }
+    }
+
+    // Ensure trauma object matches monster structure
+    if (!systemData.conditions.trauma || typeof systemData.conditions.trauma !== 'object') {
+      systemData.conditions.trauma = {};
+    }
+    const traumaLocations = ["head", "torso", "leftArm", "rightArm", "leftLeg", "rightLeg"];
+    for (const loc of traumaLocations) {
+      if (!systemData.conditions.trauma[loc] || typeof systemData.conditions.trauma[loc].value !== 'number') {
+        systemData.conditions.trauma[loc] = { value: 0 };
       }
     }
 

--- a/scripts/item-sheet.js
+++ b/scripts/item-sheet.js
@@ -83,7 +83,30 @@ export class WitchIronItemSheet extends ItemSheet {
         "impaired": "Impaired"
       };
     }
-    
+
+    // Weapon specific options
+    if (context.item.type === 'weapon') {
+      const skillOpts = {};
+      for (const [cat, skills] of Object.entries(CONFIG.WITCH_IRON.skills)) {
+        for (const [key, val] of Object.entries(skills)) {
+          skillOpts[key] = val.label;
+        }
+      }
+      context.skillOptions = skillOpts;
+    }
+
+    // Armor location options
+    if (context.item.type === 'armor') {
+      context.locationOptions = {
+        head: 'Head',
+        torso: 'Torso',
+        leftArm: 'Left Arm',
+        rightArm: 'Right Arm',
+        leftLeg: 'Left Leg',
+        rightLeg: 'Right Leg'
+      };
+    }
+
     return context;
   }
 
@@ -131,14 +154,27 @@ export class WitchIronItemSheet extends ItemSheet {
    * Prepare weapon specific data
    */
   _prepareWeaponData(context) {
-    // Add weapon specific data if needed
+    if (!context.system.damage) context.system.damage = { value: "", bonus: 0 };
+    if (typeof context.system.damage.bonus !== 'number') {
+      context.system.damage.bonus = Number(context.system.damage.bonus) || 0;
+    }
+    if (!context.system.skill) context.system.skill = 'melee';
+    if (context.system.specialization === undefined) context.system.specialization = '';
+    if (!context.system.wear) context.system.wear = { value: 0 };
   }
 
   /** 
    * Prepare armor specific data
    */
   _prepareArmorData(context) {
-    // Add armor specific data if needed
+    const LOCS = ["head","torso","leftArm","rightArm","leftLeg","rightLeg"];
+    if (!context.system.protection) context.system.protection = { value: 0 };
+    if (!context.system.locations) context.system.locations = {};
+    if (!context.system.wear) context.system.wear = {};
+    for (const loc of LOCS) {
+      if (context.system.locations[loc] === undefined) context.system.locations[loc] = false;
+      if (!context.system.wear[loc]) context.system.wear[loc] = { value: 0 };
+    }
   }
 
   /**

--- a/scripts/item.js
+++ b/scripts/item.js
@@ -64,8 +64,13 @@ export class WitchIronItem extends Item {
    * @private
    */
   _prepareWeaponData(itemData) {
-    // Any weapon-specific derivations would go here
-    // For example, calculating total damage based on properties
+    if (!itemData.damage) itemData.damage = { value: "", bonus: 0 };
+    if (typeof itemData.damage.bonus !== 'number') {
+      itemData.damage.bonus = Number(itemData.damage.bonus) || 0;
+    }
+    if (!itemData.skill) itemData.skill = 'melee';
+    if (itemData.specialization === undefined) itemData.specialization = '';
+    if (!itemData.wear) itemData.wear = { value: 0 };
   }
 
   /**
@@ -74,8 +79,14 @@ export class WitchIronItem extends Item {
    * @private
    */
   _prepareArmorData(itemData) {
-    // Any armor-specific derivations would go here
-    // For example, calculating effective protection based on condition
+    const LOCS = ["head","torso","leftArm","rightArm","leftLeg","rightLeg"];
+    if (!itemData.protection) itemData.protection = { value: 0 };
+    if (!itemData.locations) itemData.locations = {};
+    if (!itemData.wear) itemData.wear = {};
+    for (const loc of LOCS) {
+      if (itemData.locations[loc] === undefined) itemData.locations[loc] = false;
+      if (!itemData.wear[loc]) itemData.wear[loc] = { value: 0 };
+    }
   }
 
   /**

--- a/scripts/witch-iron.js
+++ b/scripts/witch-iron.js
@@ -11,6 +11,7 @@ import { WitchIronMonsterSheet } from "./monster-sheet.js";
 import { WitchIronActor } from "./actor.js";
 import { WitchIronItem } from "./item.js";
 import { WitchIronInjurySheet } from "./injury-sheet.js";
+import { WitchIronItemSheet } from "./item-sheet.js";
 import { initQuarrel, manualQuarrel, quarrelTracker } from "./quarrel.js";
 import { HitLocationSelector } from "./hit-location.js";
 import { InjuryTables } from "./injury-tables.js";
@@ -193,6 +194,12 @@ Hooks.once("init", function() {
     types: ["injury"],
     makeDefault: true,
     label: "Witch Iron Injury"
+  });
+
+  Items.registerSheet("witch-iron", WitchIronItemSheet, {
+    types: ["weapon", "armor", "gear", "consumable", "artifact", "mutation", "madness"],
+    makeDefault: true,
+    label: "Witch Iron Item"
   });
   
   // Initialize the Quarrel system

--- a/styles/witch-iron.css
+++ b/styles/witch-iron.css
@@ -795,6 +795,27 @@
   resize: vertical;
 }
 
+/* Item sheet resource blocks */
+.witch-iron.sheet.item .resource {
+  margin-bottom: 10px;
+  padding: 5px;
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 3px;
+}
+
+.witch-iron.sheet.item .resource label {
+  display: block;
+  font-weight: bold;
+  margin-bottom: 3px;
+}
+
+.witch-iron.sheet.item .resource input,
+.witch-iron.sheet.item .resource textarea,
+.witch-iron.sheet.item .resource select {
+  width: 100%;
+  padding: 4px;
+}
+
 /* ----------------------------------------- */
 /*  Chat Message Styles                      */
 /* ----------------------------------------- */

--- a/templates/items/armor-sheet.hbs
+++ b/templates/items/armor-sheet.hbs
@@ -28,7 +28,27 @@
           <label class="resource-label">Protection</label>
           <input type="number" name="system.protection.value" value="{{system.protection.value}}" data-dtype="Number"/>
         </div>
-        
+
+        <div class="resource">
+          <label class="resource-label">Locations</label>
+          <div class="flexcol">
+            {{#each locationOptions as |label key|}}
+            <label class="checkbox"><input type="checkbox" name="system.locations.{{key}}" {{#if (lookup ../system.locations key)}}checked{{/if}}> {{label}}</label>
+            {{/each}}
+          </div>
+        </div>
+
+        <div class="resource">
+          <label class="resource-label">Wear by Location</label>
+          <div class="flexrow wrap">
+            {{#each locationOptions as |label key|}}
+            <label class="nowrap">{{label}}
+              <input type="number" name="system.wear.{{key}}.value" value="{{lookup ../system.wear key}.value}}" data-dtype="Number" class="short"/>
+            </label>
+            {{/each}}
+          </div>
+        </div>
+
         <div class="resource">
           <label class="resource-label">Encumbrance</label>
           <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>

--- a/templates/items/weapon-sheet.hbs
+++ b/templates/items/weapon-sheet.hbs
@@ -28,7 +28,31 @@
           <label class="resource-label">Damage</label>
           <input type="text" name="system.damage.value" value="{{system.damage.value}}" placeholder="e.g., 1d6+2"/>
         </div>
-        
+
+        <div class="resource">
+          <label class="resource-label">Damage Bonus</label>
+          <input type="number" name="system.damage.bonus" value="{{system.damage.bonus}}" data-dtype="Number"/>
+        </div>
+
+        <div class="resource">
+          <label class="resource-label">Skill</label>
+          <select name="system.skill">
+            {{#each skillOptions as |label key|}}
+            <option value="{{key}}" {{#if (eq ../system.skill key)}}selected="selected"{{/if}}>{{label}}</option>
+            {{/each}}
+          </select>
+        </div>
+
+        <div class="resource">
+          <label class="resource-label">Specialization</label>
+          <input type="text" name="system.specialization" value="{{system.specialization}}"/>
+        </div>
+
+        <div class="resource">
+          <label class="resource-label">Battle Wear</label>
+          <input type="number" name="system.wear.value" value="{{system.wear.value}}" data-dtype="Number"/>
+        </div>
+
         <div class="resource">
           <label class="resource-label">Encumbrance</label>
           <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>


### PR DESCRIPTION
## Summary
- expand descendant conditions to match monsters
- add weapon and armor defaults and sheet options
- support new weapon fields and armor location checkboxes
- register item sheets for all item types
- refine item sheet layouts and add wear fields

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68433b9f39d8832d9f873cf32e2f0de2