### PR TITLE
Enhance item sheet registration and wear tracking

### DIFF
--- a/scripts/witch-iron.js
+++ b/scripts/witch-iron.js
@@ -11,6 +11,7 @@ import { WitchIronMonsterSheet } from "./monster-sheet.js";
 import { WitchIronActor } from "./actor.js";
 import { WitchIronItem } from "./item.js";
 import { WitchIronInjurySheet } from "./injury-sheet.js";
+import { WitchIronItemSheet } from "./item-sheet.js";
 import { initQuarrel, manualQuarrel, quarrelTracker } from "./quarrel.js";
 import { HitLocationSelector } from "./hit-location.js";
 import { InjuryTables } from "./injury-tables.js";
@@ -193,6 +194,12 @@ Hooks.once("init", function() {
     types: ["injury"],
     makeDefault: true,
     label: "Witch Iron Injury"
+  });
+
+  Items.registerSheet("witch-iron", WitchIronItemSheet, {
+    types: ["weapon", "armor", "gear", "consumable", "artifact", "mutation", "madness"],
+    makeDefault: true,
+    label: "Witch Iron Item"
   });
   
   // Initialize the Quarrel system

--- a/styles/witch-iron.css
+++ b/styles/witch-iron.css
@@ -795,6 +795,18 @@
   resize: vertical;
 }
 
+/* Resource block layout for item sheets */
+.witch-iron.sheet.item .resource {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 10px;
+}
+
+.witch-iron.sheet.item .resource-label {
+  font-weight: bold;
+  margin-bottom: 3px;
+}
+
 /* ----------------------------------------- */
 /*  Chat Message Styles                      */
 /* ----------------------------------------- */

--- a/templates/items/armor-sheet.hbs
+++ b/templates/items/armor-sheet.hbs
@@ -43,6 +43,34 @@
           <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>
         </div>
       </div>
+
+      <h4>Wear</h4>
+      <div class="grid grid-3col">
+        <div class="resource">
+          <label class="resource-label">Head</label>
+          <input type="number" name="system.wear.head.value" value="{{system.wear.head.value}}" data-dtype="Number"/>
+        </div>
+        <div class="resource">
+          <label class="resource-label">Torso</label>
+          <input type="number" name="system.wear.torso.value" value="{{system.wear.torso.value}}" data-dtype="Number"/>
+        </div>
+        <div class="resource">
+          <label class="resource-label">Left Arm</label>
+          <input type="number" name="system.wear.leftArm.value" value="{{system.wear.leftArm.value}}" data-dtype="Number"/>
+        </div>
+        <div class="resource">
+          <label class="resource-label">Right Arm</label>
+          <input type="number" name="system.wear.rightArm.value" value="{{system.wear.rightArm.value}}" data-dtype="Number"/>
+        </div>
+        <div class="resource">
+          <label class="resource-label">Left Leg</label>
+          <input type="number" name="system.wear.leftLeg.value" value="{{system.wear.leftLeg.value}}" data-dtype="Number"/>
+        </div>
+        <div class="resource">
+          <label class="resource-label">Right Leg</label>
+          <input type="number" name="system.wear.rightLeg.value" value="{{system.wear.rightLeg.value}}" data-dtype="Number"/>
+        </div>
+      </div>
       
       <div class="form-group">
         <label>Penalties</label>

--- a/templates/items/weapon-sheet.hbs
+++ b/templates/items/weapon-sheet.hbs
@@ -52,6 +52,11 @@
           <label class="resource-label">Encumbrance</label>
           <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>
         </div>
+
+        <div class="resource">
+          <label class="resource-label">Battle Wear</label>
+          <input type="number" name="system.wear.value" value="{{system.wear.value}}" data-dtype="Number"/>
+        </div>
       </div>
       
       <div class="form-group">


### PR DESCRIPTION
## Summary
- import WitchIronItemSheet and register it for all standard item types
- style item sheet resource blocks
- add battle wear tracking for weapons
- add per-location wear fields for armor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843426619d4832dbfd862fe168dec7c