### PR TITLE
Enhance item sheet handling

### DIFF
--- a/scripts/item-sheet.js
+++ b/scripts/item-sheet.js
@@ -161,6 +161,10 @@ export class WitchIronItemSheet extends ItemSheet {
     if (!context.system.skill) context.system.skill = 'melee';
     if (context.system.specialization === undefined) context.system.specialization = '';
     if (!context.system.wear) context.system.wear = { value: 0 };
+    if (!context.system.ability) {
+      context.system.ability = context.system.skill === 'ranged' ? 'quickness' : 'muscle';
+    }
+    context.abilityOptions = CONFIG.WITCH_IRON.attributes;
   }
 
   /** 
@@ -285,6 +289,23 @@ export class WitchIronItemSheet extends ItemSheet {
     }
     
     // Other item type specific listeners can be added in similar blocks
+  }
+
+  /** @override */
+  async _updateObject(event, formData) {
+    await super._updateObject(event, formData);
+    if (!this.item.actor) return;
+    if (this.item.type === 'weapon' && this.item.system.equipped) {
+      const val = this.item.system.wear?.value || 0;
+      await this.item.actor.update({ 'system.battleWear.weapon.value': val });
+    } else if (this.item.type === 'armor' && this.item.system.equipped) {
+      const locs = ["head","torso","leftArm","rightArm","leftLeg","rightLeg"];
+      const update = {};
+      for (const loc of locs) {
+        update[`system.battleWear.armor.${loc}.value`] = this.item.system.wear?.[loc]?.value || 0;
+      }
+      await this.item.actor.update(update);
+    }
   }
 
   /** @override */

--- a/scripts/witch-iron.js
+++ b/scripts/witch-iron.js
@@ -11,6 +11,7 @@ import { WitchIronMonsterSheet } from "./monster-sheet.js";
 import { WitchIronActor } from "./actor.js";
 import { WitchIronItem } from "./item.js";
 import { WitchIronInjurySheet } from "./injury-sheet.js";
+import { WitchIronItemSheet } from "./item-sheet.js";
 import { initQuarrel, manualQuarrel, quarrelTracker } from "./quarrel.js";
 import { HitLocationSelector } from "./hit-location.js";
 import { InjuryTables } from "./injury-tables.js";
@@ -193,6 +194,12 @@ Hooks.once("init", function() {
     types: ["injury"],
     makeDefault: true,
     label: "Witch Iron Injury"
+  });
+
+  Items.registerSheet("witch-iron", WitchIronItemSheet, {
+    types: ["weapon", "armor", "gear", "consumable", "artifact", "mutation", "madness"],
+    makeDefault: true,
+    label: "Witch Iron Item"
   });
   
   // Initialize the Quarrel system

--- a/styles/witch-iron.css
+++ b/styles/witch-iron.css
@@ -579,6 +579,11 @@
   text-align: center;
 }
 
+.witch-iron.sheet.descendant .item-equipped {
+  flex: 0 0 60px;
+  text-align: center;
+}
+
 .witch-iron.sheet.descendant .item-controls {
   flex: 0 0 60px;
   text-align: right;
@@ -793,6 +798,18 @@
 
 .witch-iron.sheet.item .form-group textarea {
   resize: vertical;
+}
+
+/* Resource block layout for item sheets */
+.witch-iron.sheet.item .resource {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 10px;
+}
+
+.witch-iron.sheet.item .resource-label {
+  font-weight: bold;
+  margin-bottom: 3px;
 }
 
 /* ----------------------------------------- */

--- a/templates/actors/descendant-sheet.hbs
+++ b/templates/actors/descendant-sheet.hbs
@@ -622,6 +622,7 @@
                   <div class="item-name">Name</div>
                   <div class="item-damage">Damage</div>
                   <div class="item-weight">Weight</div>
+                  <div class="item-equipped">Worn?</div>
                   <div class="item-controls"></div>
                 </div>
                 {{#each weapons as |item id|}}
@@ -629,6 +630,7 @@
                   <div class="item-name item-roll">{{item.name}}</div>
                   <div class="item-damage">{{item.system.damage}}</div>
                   <div class="item-weight">{{item.system.encumbrance.value}}</div>
+                  <div class="item-equipped"><input type="checkbox" class="item-equipped-checkbox" {{#if item.system.equipped}}checked{{/if}}></div>
                   <div class="item-controls">
                     <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
                     <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
@@ -646,6 +648,7 @@
                   <div class="item-name">Name</div>
                   <div class="item-defense">Defense</div>
                   <div class="item-weight">Weight</div>
+                  <div class="item-equipped">Worn?</div>
                   <div class="item-controls"></div>
                 </div>
                 {{#each armor as |item id|}}
@@ -653,6 +656,7 @@
                   <div class="item-name">{{item.name}}</div>
                   <div class="item-defense">{{item.system.defense}}</div>
                   <div class="item-weight">{{item.system.encumbrance.value}}</div>
+                  <div class="item-equipped"><input type="checkbox" class="item-equipped-checkbox" {{#if item.system.equipped}}checked{{/if}}></div>
                   <div class="item-controls">
                     <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
                     <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>

--- a/templates/items/armor-sheet.hbs
+++ b/templates/items/armor-sheet.hbs
@@ -1,4 +1,4 @@
-<section class="{{cssClass}} flexcol">
+<form class="{{cssClass}} flexcol" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
     <div class="header-fields">
@@ -8,21 +8,12 @@
     </div>
   </header>
 
-  {{!-- Sheet Tab Navigation --}}
-  <nav class="sheet-tabs tabs" data-group="primary">
-    <a class="item" data-tab="description">Description</a>
-    <a class="item" data-tab="attributes">Attributes</a>
-  </nav>
+  <div class="form-group">
+    <label>Description</label>
+    <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
+  </div>
 
-  {{!-- Sheet Body --}}
-  <section class="sheet-body">
-    {{!-- Description Tab --}}
-    <div class="tab" data-group="primary" data-tab="description">
-      <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
-    </div>
-
-    {{!-- Attributes Tab --}}
-    <div class="tab" data-group="primary" data-tab="attributes">
+  <div class="grid grid-3col">
       <div class="grid grid-3col">
         <div class="resource">
           <label class="resource-label">Protection</label>
@@ -42,12 +33,38 @@
           <label class="resource-label">Encumbrance</label>
           <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>
         </div>
-      </div>
-      
-      <div class="form-group">
-        <label>Penalties</label>
-        <textarea name="system.penalties">{{system.penalties}}</textarea>
-      </div>
-    </div>
-  </section>
-</section> 
+  </div>
+
+  <h4>Wear</h4>
+  <div class="grid grid-3col">
+        <div class="resource">
+          <label class="resource-label">Head</label>
+          <input type="number" name="system.wear.head.value" value="{{system.wear.head.value}}" data-dtype="Number"/>
+        </div>
+        <div class="resource">
+          <label class="resource-label">Torso</label>
+          <input type="number" name="system.wear.torso.value" value="{{system.wear.torso.value}}" data-dtype="Number"/>
+        </div>
+        <div class="resource">
+          <label class="resource-label">Left Arm</label>
+          <input type="number" name="system.wear.leftArm.value" value="{{system.wear.leftArm.value}}" data-dtype="Number"/>
+        </div>
+        <div class="resource">
+          <label class="resource-label">Right Arm</label>
+          <input type="number" name="system.wear.rightArm.value" value="{{system.wear.rightArm.value}}" data-dtype="Number"/>
+        </div>
+        <div class="resource">
+          <label class="resource-label">Left Leg</label>
+          <input type="number" name="system.wear.leftLeg.value" value="{{system.wear.leftLeg.value}}" data-dtype="Number"/>
+        </div>
+        <div class="resource">
+          <label class="resource-label">Right Leg</label>
+          <input type="number" name="system.wear.rightLeg.value" value="{{system.wear.rightLeg.value}}" data-dtype="Number"/>
+        </div>
+  </div>
+
+  <div class="form-group">
+    <label>Penalties</label>
+    <textarea name="system.penalties">{{system.penalties}}</textarea>
+  </div>
+</form>

--- a/templates/items/artifact-sheet.hbs
+++ b/templates/items/artifact-sheet.hbs
@@ -1,4 +1,4 @@
-<section class="{{cssClass}} flexcol">
+<form class="{{cssClass}} flexcol" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
     <div class="header-fields">
@@ -8,39 +8,26 @@
     </div>
   </header>
 
-  {{!-- Sheet Tab Navigation --}}
-  <nav class="sheet-tabs tabs" data-group="primary">
-    <a class="item" data-tab="description">Description</a>
-    <a class="item" data-tab="attributes">Attributes</a>
-  </nav>
+  <div class="form-group">
+    <label>Description</label>
+    <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
+  </div>
 
-  {{!-- Sheet Body --}}
-  <section class="sheet-body">
-    {{!-- Description Tab --}}
-    <div class="tab" data-group="primary" data-tab="description">
-      <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
+  <div class="grid grid-3col">
+    <div class="resource">
+      <label class="resource-label">Stage</label>
+      <select name="system.stage.value" data-dtype="Number">
+        {{selectOptions stageOptions selected=system.stage.value localize=false}}
+      </select>
     </div>
+    <div class="resource">
+      <label class="resource-label">Encumbrance</label>
+      <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>
+    </div>
+  </div>
 
-    {{!-- Attributes Tab --}}
-    <div class="tab" data-group="primary" data-tab="attributes">
-      <div class="grid grid-3col">
-        <div class="resource">
-          <label class="resource-label">Stage</label>
-          <select name="system.stage.value" data-dtype="Number">
-            {{selectOptions stageOptions selected=system.stage.value localize=false}}
-          </select>
-        </div>
-        
-        <div class="resource">
-          <label class="resource-label">Encumbrance</label>
-          <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>
-        </div>
-      </div>
-      
-      <div class="form-group">
-        <label>Lineage</label>
-        <input type="text" name="system.lineage" value="{{system.lineage}}" placeholder="e.g., Blood, Death, Knowledge"/>
-      </div>
-    </div>
-  </section>
-</section> 
+  <div class="form-group">
+    <label>Lineage</label>
+    <input type="text" name="system.lineage" value="{{system.lineage}}" placeholder="e.g., Blood, Death, Knowledge"/>
+  </div>
+</form>

--- a/templates/items/consumable-sheet.hbs
+++ b/templates/items/consumable-sheet.hbs
@@ -1,4 +1,4 @@
-<section class="{{cssClass}} flexcol">
+<form class="{{cssClass}} flexcol" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
     <div class="header-fields">
@@ -8,41 +8,28 @@
     </div>
   </header>
 
-  {{!-- Sheet Tab Navigation --}}
-  <nav class="sheet-tabs tabs" data-group="primary">
-    <a class="item" data-tab="description">Description</a>
-    <a class="item" data-tab="attributes">Attributes</a>
-  </nav>
+  <div class="form-group">
+    <label>Description</label>
+    <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
+  </div>
 
-  {{!-- Sheet Body --}}
-  <section class="sheet-body">
-    {{!-- Description Tab --}}
-    <div class="tab" data-group="primary" data-tab="description">
-      <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
-    </div>
-
-    {{!-- Attributes Tab --}}
-    <div class="tab" data-group="primary" data-tab="attributes">
-      <div class="grid grid-3col">
-        <div class="resource">
-          <label class="resource-label">Charges</label>
-          <div class="resource-content flexrow flex-center flex-between">
-            <input type="number" name="system.charges.value" value="{{system.charges.value}}" data-dtype="Number"/>
-            <span> / </span>
-            <input type="number" name="system.charges.max" value="{{system.charges.max}}" data-dtype="Number"/>
-          </div>
-        </div>
-        
-        <div class="resource">
-          <label class="resource-label">Encumbrance</label>
-          <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>
-        </div>
-      </div>
-      
-      <div class="form-group">
-        <label>Effect</label>
-        <textarea name="system.effect">{{system.effect}}</textarea>
+  <div class="grid grid-3col">
+    <div class="resource">
+      <label class="resource-label">Charges</label>
+      <div class="resource-content flexrow flex-center flex-between">
+        <input type="number" name="system.charges.value" value="{{system.charges.value}}" data-dtype="Number"/>
+        <span> / </span>
+        <input type="number" name="system.charges.max" value="{{system.charges.max}}" data-dtype="Number"/>
       </div>
     </div>
-  </section>
-</section> 
+    <div class="resource">
+      <label class="resource-label">Encumbrance</label>
+      <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <label>Effect</label>
+    <textarea name="system.effect">{{system.effect}}</textarea>
+  </div>
+</form>

--- a/templates/items/gear-sheet.hbs
+++ b/templates/items/gear-sheet.hbs
@@ -1,4 +1,4 @@
-<section class="{{cssClass}} flexcol">
+<form class="{{cssClass}} flexcol" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
     <div class="header-fields">
@@ -8,25 +8,13 @@
     </div>
   </header>
 
-  {{!-- Sheet Tab Navigation --}}
-  <nav class="sheet-tabs tabs" data-group="primary">
-    <a class="item" data-tab="description">Description</a>
-    <a class="item" data-tab="attributes">Attributes</a>
-  </nav>
+  <div class="form-group">
+    <label>Description</label>
+    <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
+  </div>
 
-  {{!-- Sheet Body --}}
-  <section class="sheet-body">
-    {{!-- Description Tab --}}
-    <div class="tab" data-group="primary" data-tab="description">
-      <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
-    </div>
-
-    {{!-- Attributes Tab --}}
-    <div class="tab" data-group="primary" data-tab="attributes">
-      <div class="resource">
-        <label class="resource-label">Encumbrance</label>
-        <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>
-      </div>
-    </div>
-  </section>
-</section> 
+  <div class="resource">
+    <label class="resource-label">Encumbrance</label>
+    <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>
+  </div>
+</form>

--- a/templates/items/item-sheet.hbs
+++ b/templates/items/item-sheet.hbs
@@ -8,91 +8,75 @@
     </div>
   </header>
 
-  {{!-- Sheet Tab Navigation --}}
-  <nav class="sheet-tabs tabs" data-group="primary">
-    <a class="item" data-tab="description">Description</a>
-    <a class="item" data-tab="details">Details</a>
-  </nav>
+  <div class="form-group">
+    <label>Description</label>
+    <textarea name="system.description" rows="8">{{system.description}}</textarea>
+  </div>
 
-  {{!-- Sheet Body --}}
-  <section class="sheet-body">
+  <div class="form-group">
+    <label>Encumbrance</label>
+    <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>
+  </div>
 
-    {{!-- Description Tab --}}
-    <div class="tab" data-group="primary" data-tab="description">
-      <div class="form-group">
-        <label>Description</label>
-        <textarea name="system.description" rows="8">{{system.description}}</textarea>
-      </div>
+  {{#if (eq item.type "weapon")}}
+  <div class="form-group">
+    <label>Damage</label>
+    <input type="text" name="system.damage.value" value="{{system.damage.value}}"/>
+  </div>
+  <div class="form-group">
+    <label>Properties</label>
+    <input type="text" name="system.properties" value="{{system.properties}}"/>
+  </div>
+  {{/if}}
+
+  {{#if (eq item.type "armor")}}
+  <div class="form-group">
+    <label>Protection</label>
+    <input type="number" name="system.protection.value" value="{{system.protection.value}}" data-dtype="Number"/>
+  </div>
+  <div class="form-group">
+    <label>Penalties</label>
+    <input type="text" name="system.penalties" value="{{system.penalties}}"/>
+  </div>
+  {{/if}}
+
+  {{#if (eq item.type "consumable")}}
+  <div class="form-group">
+    <label>Charges</label>
+    <div class="flexrow">
+      <input type="number" name="system.charges.value" value="{{system.charges.value}}" data-dtype="Number"/>
+      <span>/</span>
+      <input type="number" name="system.charges.max" value="{{system.charges.max}}" data-dtype="Number"/>
     </div>
+  </div>
+  <div class="form-group">
+    <label>Effect</label>
+    <textarea name="system.effect" rows="4">{{system.effect}}</textarea>
+  </div>
+  {{/if}}
 
-    {{!-- Details Tab --}}
-    <div class="tab" data-group="primary" data-tab="details">
-      <div class="form-group">
-        <label>Encumbrance</label>
-        <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>
-      </div>
+  {{#if (eq item.type "artifact")}}
+  <div class="form-group">
+    <label>Stage</label>
+    <input type="number" name="system.stage.value" value="{{system.stage.value}}" data-dtype="Number"/>
+  </div>
+  <div class="form-group">
+    <label>Lineage</label>
+    <input type="text" name="system.lineage" value="{{system.lineage}}"/>
+  </div>
+  {{/if}}
 
-      {{#if (eq item.type "weapon")}}
-      <div class="form-group">
-        <label>Damage</label>
-        <input type="text" name="system.damage.value" value="{{system.damage.value}}"/>
-      </div>
-      <div class="form-group">
-        <label>Properties</label>
-        <input type="text" name="system.properties" value="{{system.properties}}"/>
-      </div>
-      {{/if}}
+  {{#if (eq item.type "mutation")}}
+  <div class="form-group">
+    <label>Effect</label>
+    <textarea name="system.effect" rows="4">{{system.effect}}</textarea>
+  </div>
+  {{/if}}
 
-      {{#if (eq item.type "armor")}}
-      <div class="form-group">
-        <label>Protection</label>
-        <input type="number" name="system.protection.value" value="{{system.protection.value}}" data-dtype="Number"/>
-      </div>
-      <div class="form-group">
-        <label>Penalties</label>
-        <input type="text" name="system.penalties" value="{{system.penalties}}"/>
-      </div>
-      {{/if}}
-
-      {{#if (eq item.type "consumable")}}
-      <div class="form-group">
-        <label>Charges</label>
-        <div class="flexrow">
-          <input type="number" name="system.charges.value" value="{{system.charges.value}}" data-dtype="Number"/>
-          <span>/</span>
-          <input type="number" name="system.charges.max" value="{{system.charges.max}}" data-dtype="Number"/>
-        </div>
-      </div>
-      <div class="form-group">
-        <label>Effect</label>
-        <textarea name="system.effect" rows="4">{{system.effect}}</textarea>
-      </div>
-      {{/if}}
-
-      {{#if (eq item.type "artifact")}}
-      <div class="form-group">
-        <label>Stage</label>
-        <input type="number" name="system.stage.value" value="{{system.stage.value}}" data-dtype="Number"/>
-      </div>
-      <div class="form-group">
-        <label>Lineage</label>
-        <input type="text" name="system.lineage" value="{{system.lineage}}"/>
-      </div>
-      {{/if}}
-
-      {{#if (eq item.type "mutation")}}
-      <div class="form-group">
-        <label>Effect</label>
-        <textarea name="system.effect" rows="4">{{system.effect}}</textarea>
-      </div>
-      {{/if}}
-
-      {{#if (eq item.type "madness")}}
-      <div class="form-group">
-        <label>Effect</label>
-        <textarea name="system.effect" rows="4">{{system.effect}}</textarea>
-      </div>
-      {{/if}}
-    </div>
-  </section>
-</form> 
+  {{#if (eq item.type "madness")}}
+  <div class="form-group">
+    <label>Effect</label>
+    <textarea name="system.effect" rows="4">{{system.effect}}</textarea>
+  </div>
+  {{/if}}
+</form>

--- a/templates/items/madness-sheet.hbs
+++ b/templates/items/madness-sheet.hbs
@@ -1,4 +1,4 @@
-<section class="{{cssClass}} flexcol">
+<form class="{{cssClass}} flexcol" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
     <div class="header-fields">
@@ -8,25 +8,13 @@
     </div>
   </header>
 
-  {{!-- Sheet Tab Navigation --}}
-  <nav class="sheet-tabs tabs" data-group="primary">
-    <a class="item" data-tab="description">Description</a>
-    <a class="item" data-tab="effects">Effects</a>
-  </nav>
+  <div class="form-group">
+    <label>Description</label>
+    <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
+  </div>
 
-  {{!-- Sheet Body --}}
-  <section class="sheet-body">
-    {{!-- Description Tab --}}
-    <div class="tab" data-group="primary" data-tab="description">
-      <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
-    </div>
-
-    {{!-- Effects Tab --}}
-    <div class="tab" data-group="primary" data-tab="effects">
-      <div class="form-group">
-        <label>Effect</label>
-        <textarea name="system.effect" placeholder="Mental/behavioral effects">{{system.effect}}</textarea>
-      </div>
-    </div>
-  </section>
-</section> 
+  <div class="form-group">
+    <label>Effect</label>
+    <textarea name="system.effect" placeholder="Mental/behavioral effects">{{system.effect}}</textarea>
+  </div>
+</form>

--- a/templates/items/mutation-sheet.hbs
+++ b/templates/items/mutation-sheet.hbs
@@ -1,4 +1,4 @@
-<section class="{{cssClass}} flexcol">
+<form class="{{cssClass}} flexcol" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
     <div class="header-fields">
@@ -8,25 +8,13 @@
     </div>
   </header>
 
-  {{!-- Sheet Tab Navigation --}}
-  <nav class="sheet-tabs tabs" data-group="primary">
-    <a class="item" data-tab="description">Description</a>
-    <a class="item" data-tab="effects">Effects</a>
-  </nav>
+  <div class="form-group">
+    <label>Description</label>
+    <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
+  </div>
 
-  {{!-- Sheet Body --}}
-  <section class="sheet-body">
-    {{!-- Description Tab --}}
-    <div class="tab" data-group="primary" data-tab="description">
-      <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
-    </div>
-
-    {{!-- Effects Tab --}}
-    <div class="tab" data-group="primary" data-tab="effects">
-      <div class="form-group">
-        <label>Effect</label>
-        <textarea name="system.effect" placeholder="Effect on the character">{{system.effect}}</textarea>
-      </div>
-    </div>
-  </section>
-</section> 
+  <div class="form-group">
+    <label>Effect</label>
+    <textarea name="system.effect" placeholder="Effect on the character">{{system.effect}}</textarea>
+  </div>
+</form>

--- a/templates/items/weapon-sheet.hbs
+++ b/templates/items/weapon-sheet.hbs
@@ -1,4 +1,4 @@
-<section class="{{cssClass}} flexcol">
+<form class="{{cssClass}} flexcol" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
     <div class="header-fields">
@@ -8,56 +8,58 @@
     </div>
   </header>
 
-  {{!-- Sheet Tab Navigation --}}
-  <nav class="sheet-tabs tabs" data-group="primary">
-    <a class="item" data-tab="description">Description</a>
-    <a class="item" data-tab="attributes">Attributes</a>
-  </nav>
+  <div class="form-group">
+    <label>Description</label>
+    <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
+  </div>
 
-  {{!-- Sheet Body --}}
-  <section class="sheet-body">
-    {{!-- Description Tab --}}
-    <div class="tab" data-group="primary" data-tab="description">
-      <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
+  <div class="grid grid-3col">
+    <div class="resource">
+      <label class="resource-label">Damage</label>
+      <input type="text" name="system.damage.value" value="{{system.damage.value}}" placeholder="e.g., 1d6+2"/>
     </div>
 
-    {{!-- Attributes Tab --}}
-    <div class="tab" data-group="primary" data-tab="attributes">
-      <div class="grid grid-3col">
-        <div class="resource">
-          <label class="resource-label">Damage</label>
-          <input type="text" name="system.damage.value" value="{{system.damage.value}}" placeholder="e.g., 1d6+2"/>
-        </div>
-
-        <div class="resource">
-          <label class="resource-label">Damage Bonus</label>
-          <input type="number" name="system.damage.bonus" value="{{system.damage.bonus}}" data-dtype="Number"/>
-        </div>
-
-        <div class="resource">
-          <label class="resource-label">Skill</label>
-          <select name="system.skill">
-            {{#each skillOptions as |label key|}}
-            <option value="{{key}}" {{#if (eq ../system.skill key)}}selected="selected"{{/if}}>{{label}}</option>
-            {{/each}}
-          </select>
-        </div>
-
-        <div class="resource">
-          <label class="resource-label">Specialization</label>
-          <input type="text" name="system.specialization" value="{{system.specialization}}"/>
-        </div>
-
-        <div class="resource">
-          <label class="resource-label">Encumbrance</label>
-          <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>
-        </div>
-      </div>
-      
-      <div class="form-group">
-        <label>Properties</label>
-        <textarea name="system.properties">{{system.properties}}</textarea>
-      </div>
+    <div class="resource">
+      <label class="resource-label">Damage Bonus</label>
+      <input type="number" name="system.damage.bonus" value="{{system.damage.bonus}}" data-dtype="Number"/>
     </div>
-  </section>
-</section> 
+
+    <div class="resource">
+      <label class="resource-label">Ability Bonus</label>
+      <select name="system.ability">
+        {{#each abilityOptions as |label key|}}
+        <option value="{{key}}" {{#if (eq ../system.ability key)}}selected="selected"{{/if}}>{{label}}</option>
+        {{/each}}
+      </select>
+    </div>
+
+    <div class="resource">
+      <label class="resource-label">Skill</label>
+      <select name="system.skill">
+        {{#each skillOptions as |label key|}}
+        <option value="{{key}}" {{#if (eq ../system.skill key)}}selected="selected"{{/if}}>{{label}}</option>
+        {{/each}}
+      </select>
+    </div>
+
+    <div class="resource">
+      <label class="resource-label">Specialization</label>
+      <input type="text" name="system.specialization" value="{{system.specialization}}"/>
+    </div>
+
+    <div class="resource">
+      <label class="resource-label">Encumbrance</label>
+      <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>
+    </div>
+
+    <div class="resource">
+      <label class="resource-label">Battle Wear</label>
+      <input type="number" name="system.wear.value" value="{{system.wear.value}}" data-dtype="Number"/>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <label>Properties</label>
+    <textarea name="system.properties">{{system.properties}}</textarea>
+  </div>
+</form>


### PR DESCRIPTION
## Summary
- ensure all item sheets use a single-page `<form>` layout
- add ability selection and update sync for battle wear
- update descendant sheet equipment list with wearable checkboxes
- keep item wear values synced with actor battle wear

## Testing
- `npm test` *(fails: package.json missing)*


------
https://chatgpt.com/codex/tasks/task_e_6843426619d4832dbfd862fe168dec7c