### PR TITLE
Improve item sheet forms and battle wear sync

### DIFF
--- a/templates/actors/descendant-sheet.hbs
+++ b/templates/actors/descendant-sheet.hbs
@@ -622,6 +622,7 @@
                   <div class="item-name">Name</div>
                   <div class="item-damage">Damage</div>
                   <div class="item-weight">Weight</div>
+                  <div class="item-equipped">Worn</div>
                   <div class="item-controls"></div>
                 </div>
                 {{#each weapons as |item id|}}
@@ -629,6 +630,7 @@
                   <div class="item-name item-roll">{{item.name}}</div>
                   <div class="item-damage">{{item.system.damage}}</div>
                   <div class="item-weight">{{item.system.encumbrance.value}}</div>
+                  <div class="item-equipped"><input type="checkbox" class="equipped-checkbox" data-item-id="{{item._id}}" {{#if item.system.equipped}}checked{{/if}}></div>
                   <div class="item-controls">
                     <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
                     <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
@@ -646,6 +648,7 @@
                   <div class="item-name">Name</div>
                   <div class="item-defense">Defense</div>
                   <div class="item-weight">Weight</div>
+                  <div class="item-equipped">Worn</div>
                   <div class="item-controls"></div>
                 </div>
                 {{#each armor as |item id|}}
@@ -653,6 +656,7 @@
                   <div class="item-name">{{item.name}}</div>
                   <div class="item-defense">{{item.system.defense}}</div>
                   <div class="item-weight">{{item.system.encumbrance.value}}</div>
+                  <div class="item-equipped"><input type="checkbox" class="equipped-checkbox" data-item-id="{{item._id}}" {{#if item.system.equipped}}checked{{/if}}></div>
                   <div class="item-controls">
                     <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
                     <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>

--- a/templates/items/armor-sheet.hbs
+++ b/templates/items/armor-sheet.hbs
@@ -1,4 +1,4 @@
-<section class="{{cssClass}} flexcol">
+<form class="{{cssClass}} flexcol" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
     <div class="header-fields">
@@ -8,22 +8,13 @@
     </div>
   </header>
 
-  {{!-- Sheet Tab Navigation --}}
-  <nav class="sheet-tabs tabs" data-group="primary">
-    <a class="item" data-tab="description">Description</a>
-    <a class="item" data-tab="attributes">Attributes</a>
-  </nav>
-
-  {{!-- Sheet Body --}}
   <section class="sheet-body">
-    {{!-- Description Tab --}}
-    <div class="tab" data-group="primary" data-tab="description">
+    <div class="form-group">
+      <label>Description</label>
       <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
     </div>
 
-    {{!-- Attributes Tab --}}
-    <div class="tab" data-group="primary" data-tab="attributes">
-      <div class="grid grid-3col">
+    <div class="grid grid-3col">
         <div class="resource">
           <label class="resource-label">Protection</label>
           <input type="number" name="system.protection.value" value="{{system.protection.value}}" data-dtype="Number"/>
@@ -71,11 +62,10 @@
           <input type="number" name="system.wear.rightLeg.value" value="{{system.wear.rightLeg.value}}" data-dtype="Number"/>
         </div>
       </div>
-      
+
       <div class="form-group">
         <label>Penalties</label>
         <textarea name="system.penalties">{{system.penalties}}</textarea>
       </div>
-    </div>
   </section>
-</section> 
+</form>

--- a/templates/items/artifact-sheet.hbs
+++ b/templates/items/artifact-sheet.hbs
@@ -1,4 +1,4 @@
-<section class="{{cssClass}} flexcol">
+<form class="{{cssClass}} flexcol" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
     <div class="header-fields">
@@ -8,22 +8,13 @@
     </div>
   </header>
 
-  {{!-- Sheet Tab Navigation --}}
-  <nav class="sheet-tabs tabs" data-group="primary">
-    <a class="item" data-tab="description">Description</a>
-    <a class="item" data-tab="attributes">Attributes</a>
-  </nav>
-
-  {{!-- Sheet Body --}}
   <section class="sheet-body">
-    {{!-- Description Tab --}}
-    <div class="tab" data-group="primary" data-tab="description">
+    <div class="form-group">
+      <label>Description</label>
       <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
     </div>
 
-    {{!-- Attributes Tab --}}
-    <div class="tab" data-group="primary" data-tab="attributes">
-      <div class="grid grid-3col">
+    <div class="grid grid-3col">
         <div class="resource">
           <label class="resource-label">Stage</label>
           <select name="system.stage.value" data-dtype="Number">
@@ -36,11 +27,10 @@
           <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>
         </div>
       </div>
-      
+
       <div class="form-group">
         <label>Lineage</label>
         <input type="text" name="system.lineage" value="{{system.lineage}}" placeholder="e.g., Blood, Death, Knowledge"/>
       </div>
-    </div>
   </section>
-</section> 
+</form>

--- a/templates/items/consumable-sheet.hbs
+++ b/templates/items/consumable-sheet.hbs
@@ -1,4 +1,4 @@
-<section class="{{cssClass}} flexcol">
+<form class="{{cssClass}} flexcol" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
     <div class="header-fields">
@@ -8,22 +8,13 @@
     </div>
   </header>
 
-  {{!-- Sheet Tab Navigation --}}
-  <nav class="sheet-tabs tabs" data-group="primary">
-    <a class="item" data-tab="description">Description</a>
-    <a class="item" data-tab="attributes">Attributes</a>
-  </nav>
-
-  {{!-- Sheet Body --}}
   <section class="sheet-body">
-    {{!-- Description Tab --}}
-    <div class="tab" data-group="primary" data-tab="description">
+    <div class="form-group">
+      <label>Description</label>
       <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
     </div>
 
-    {{!-- Attributes Tab --}}
-    <div class="tab" data-group="primary" data-tab="attributes">
-      <div class="grid grid-3col">
+    <div class="grid grid-3col">
         <div class="resource">
           <label class="resource-label">Charges</label>
           <div class="resource-content flexrow flex-center flex-between">
@@ -38,11 +29,10 @@
           <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>
         </div>
       </div>
-      
+
       <div class="form-group">
         <label>Effect</label>
         <textarea name="system.effect">{{system.effect}}</textarea>
       </div>
-    </div>
   </section>
-</section> 
+</form>

--- a/templates/items/gear-sheet.hbs
+++ b/templates/items/gear-sheet.hbs
@@ -1,4 +1,4 @@
-<section class="{{cssClass}} flexcol">
+<form class="{{cssClass}} flexcol" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
     <div class="header-fields">
@@ -8,25 +8,15 @@
     </div>
   </header>
 
-  {{!-- Sheet Tab Navigation --}}
-  <nav class="sheet-tabs tabs" data-group="primary">
-    <a class="item" data-tab="description">Description</a>
-    <a class="item" data-tab="attributes">Attributes</a>
-  </nav>
-
-  {{!-- Sheet Body --}}
   <section class="sheet-body">
-    {{!-- Description Tab --}}
-    <div class="tab" data-group="primary" data-tab="description">
+    <div class="form-group">
+      <label>Description</label>
       <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
     </div>
 
-    {{!-- Attributes Tab --}}
-    <div class="tab" data-group="primary" data-tab="attributes">
-      <div class="resource">
-        <label class="resource-label">Encumbrance</label>
-        <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>
-      </div>
+    <div class="resource">
+      <label class="resource-label">Encumbrance</label>
+      <input type="number" name="system.encumbrance.value" value="{{system.encumbrance.value}}" data-dtype="Number"/>
     </div>
   </section>
-</section> 
+</form>

--- a/templates/items/madness-sheet.hbs
+++ b/templates/items/madness-sheet.hbs
@@ -1,4 +1,4 @@
-<section class="{{cssClass}} flexcol">
+<form class="{{cssClass}} flexcol" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
     <div class="header-fields">
@@ -8,25 +8,15 @@
     </div>
   </header>
 
-  {{!-- Sheet Tab Navigation --}}
-  <nav class="sheet-tabs tabs" data-group="primary">
-    <a class="item" data-tab="description">Description</a>
-    <a class="item" data-tab="effects">Effects</a>
-  </nav>
-
-  {{!-- Sheet Body --}}
   <section class="sheet-body">
-    {{!-- Description Tab --}}
-    <div class="tab" data-group="primary" data-tab="description">
+    <div class="form-group">
+      <label>Description</label>
       <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
     </div>
 
-    {{!-- Effects Tab --}}
-    <div class="tab" data-group="primary" data-tab="effects">
-      <div class="form-group">
-        <label>Effect</label>
-        <textarea name="system.effect" placeholder="Mental/behavioral effects">{{system.effect}}</textarea>
-      </div>
+    <div class="form-group">
+      <label>Effect</label>
+      <textarea name="system.effect" placeholder="Mental/behavioral effects">{{system.effect}}</textarea>
     </div>
   </section>
-</section> 
+</form>

--- a/templates/items/mutation-sheet.hbs
+++ b/templates/items/mutation-sheet.hbs
@@ -1,4 +1,4 @@
-<section class="{{cssClass}} flexcol">
+<form class="{{cssClass}} flexcol" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
     <div class="header-fields">
@@ -8,25 +8,15 @@
     </div>
   </header>
 
-  {{!-- Sheet Tab Navigation --}}
-  <nav class="sheet-tabs tabs" data-group="primary">
-    <a class="item" data-tab="description">Description</a>
-    <a class="item" data-tab="effects">Effects</a>
-  </nav>
-
-  {{!-- Sheet Body --}}
   <section class="sheet-body">
-    {{!-- Description Tab --}}
-    <div class="tab" data-group="primary" data-tab="description">
+    <div class="form-group">
+      <label>Description</label>
       <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
     </div>
 
-    {{!-- Effects Tab --}}
-    <div class="tab" data-group="primary" data-tab="effects">
-      <div class="form-group">
-        <label>Effect</label>
-        <textarea name="system.effect" placeholder="Effect on the character">{{system.effect}}</textarea>
-      </div>
+    <div class="form-group">
+      <label>Effect</label>
+      <textarea name="system.effect" placeholder="Effect on the character">{{system.effect}}</textarea>
     </div>
   </section>
-</section> 
+</form>

--- a/templates/items/weapon-sheet.hbs
+++ b/templates/items/weapon-sheet.hbs
@@ -1,4 +1,4 @@
-<section class="{{cssClass}} flexcol">
+<form class="{{cssClass}} flexcol" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
     <div class="header-fields">
@@ -8,22 +8,13 @@
     </div>
   </header>
 
-  {{!-- Sheet Tab Navigation --}}
-  <nav class="sheet-tabs tabs" data-group="primary">
-    <a class="item" data-tab="description">Description</a>
-    <a class="item" data-tab="attributes">Attributes</a>
-  </nav>
-
-  {{!-- Sheet Body --}}
   <section class="sheet-body">
-    {{!-- Description Tab --}}
-    <div class="tab" data-group="primary" data-tab="description">
+    <div class="form-group">
+      <label>Description</label>
       <textarea name="system.description" placeholder="Description">{{system.description}}</textarea>
     </div>
 
-    {{!-- Attributes Tab --}}
-    <div class="tab" data-group="primary" data-tab="attributes">
-      <div class="grid grid-3col">
+    <div class="grid grid-3col">
         <div class="resource">
           <label class="resource-label">Damage</label>
           <input type="text" name="system.damage.value" value="{{system.damage.value}}" placeholder="e.g., 1d6+2"/>
@@ -32,6 +23,15 @@
         <div class="resource">
           <label class="resource-label">Damage Bonus</label>
           <input type="number" name="system.damage.bonus" value="{{system.damage.bonus}}" data-dtype="Number"/>
+        </div>
+
+        <div class="resource">
+          <label class="resource-label">Ability Bonus</label>
+          <select name="system.ability">
+            {{#each abilityOptions as |label key|}}
+            <option value="{{key}}" {{#if (eq ../system.ability key)}}selected="selected"{{/if}}>{{label}}</option>
+            {{/each}}
+          </select>
         </div>
 
         <div class="resource">
@@ -58,11 +58,10 @@
           <input type="number" name="system.wear.value" value="{{system.wear.value}}" data-dtype="Number"/>
         </div>
       </div>
-      
+
       <div class="form-group">
         <label>Properties</label>
         <textarea name="system.properties">{{system.properties}}</textarea>
       </div>
-    </div>
   </section>
-</section> 
+</form>


### PR DESCRIPTION
## Summary
- add ability options for weapons and default to melee/ranged ability
- sync item wear with actor on item update
- allow toggling worn equipment from the descendant sheet
- keep item wear aligned with actor battle wear
- convert item templates to single page forms

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68434791c030832d80115f8ca19529cb