### PR TITLE
Update weapon and armor layout

### DIFF
--- a/scripts/item-sheet.js
+++ b/scripts/item-sheet.js
@@ -160,10 +160,7 @@ export class WitchIronItemSheet extends ItemSheet {
    * Prepare weapon specific data
    */
   _prepareWeaponData(context) {
-    if (!context.system.damage) context.system.damage = { value: "", bonus: 0 };
-    if (typeof context.system.damage.bonus !== 'number') {
-      context.system.damage.bonus = Number(context.system.damage.bonus) || 0;
-    }
+    if (!context.system.damage) context.system.damage = { value: "" };
     if (!context.system.skill) context.system.skill = 'melee';
     if (context.system.specialization === undefined) context.system.specialization = '';
     if (!context.system.wear) context.system.wear = { value: 0 };

--- a/scripts/item.js
+++ b/scripts/item.js
@@ -64,10 +64,7 @@ export class WitchIronItem extends Item {
    * @private
    */
   _prepareWeaponData(itemData) {
-    if (!itemData.damage) itemData.damage = { value: "", bonus: 0 };
-    if (typeof itemData.damage.bonus !== 'number') {
-      itemData.damage.bonus = Number(itemData.damage.bonus) || 0;
-    }
+    if (!itemData.damage) itemData.damage = { value: "" };
     if (!itemData.skill) itemData.skill = 'melee';
     if (itemData.specialization === undefined) itemData.specialization = '';
     if (!itemData.wear) itemData.wear = { value: 0 };

--- a/templates/actors/descendant-sheet.hbs
+++ b/templates/actors/descendant-sheet.hbs
@@ -628,7 +628,7 @@
                 {{#each weapons as |item id|}}
                 <div class="item flexrow" data-item-id="{{item._id}}">
                   <div class="item-name item-roll">{{item.name}}</div>
-                  <div class="item-damage">{{item.system.damage}}</div>
+                  <div class="item-damage">{{lookup (lookup ../system.attributes item.system.ability) 'bonus'}} ({{item.system.damage.value}})</div>
                   <div class="item-weight">{{item.system.encumbrance.value}}</div>
                   <div class="item-equipped"><input type="checkbox" class="equipped-checkbox" data-item-id="{{item._id}}" {{#if item.system.equipped}}checked{{/if}}></div>
                   <div class="item-controls">
@@ -646,7 +646,7 @@
               <div class="items-list">
                 <div class="inventory-header flexrow">
                   <div class="item-name">Name</div>
-                  <div class="item-defense">Defense</div>
+                  <div class="item-defense">AV</div>
                   <div class="item-weight">Weight</div>
                   <div class="item-equipped">Worn</div>
                   <div class="item-controls"></div>
@@ -654,7 +654,7 @@
                 {{#each armor as |item id|}}
                 <div class="item flexrow" data-item-id="{{item._id}}">
                   <div class="item-name">{{item.name}}</div>
-                  <div class="item-defense">{{item.system.defense}}</div>
+                  <div class="item-defense">{{item.system.protection.value}}</div>
                   <div class="item-weight">{{item.system.encumbrance.value}}</div>
                   <div class="item-equipped"><input type="checkbox" class="equipped-checkbox" data-item-id="{{item._id}}" {{#if item.system.equipped}}checked{{/if}}></div>
                   <div class="item-controls">

--- a/templates/items/armor-sheet.hbs
+++ b/templates/items/armor-sheet.hbs
@@ -16,7 +16,7 @@
 
     <div class="grid grid-3col">
         <div class="resource">
-          <label class="resource-label">Protection</label>
+          <label class="resource-label">Armor Value</label>
           <input type="number" name="system.protection.value" value="{{system.protection.value}}" data-dtype="Number"/>
         </div>
 
@@ -37,30 +37,42 @@
 
       <h4>Wear</h4>
       <div class="grid grid-3col">
+        {{#if system.locations.head}}
         <div class="resource">
           <label class="resource-label">Head</label>
           <input type="number" name="system.wear.head.value" value="{{system.wear.head.value}}" data-dtype="Number"/>
         </div>
+        {{/if}}
+        {{#if system.locations.torso}}
         <div class="resource">
           <label class="resource-label">Torso</label>
           <input type="number" name="system.wear.torso.value" value="{{system.wear.torso.value}}" data-dtype="Number"/>
         </div>
+        {{/if}}
+        {{#if system.locations.leftArm}}
         <div class="resource">
           <label class="resource-label">Left Arm</label>
           <input type="number" name="system.wear.leftArm.value" value="{{system.wear.leftArm.value}}" data-dtype="Number"/>
         </div>
+        {{/if}}
+        {{#if system.locations.rightArm}}
         <div class="resource">
           <label class="resource-label">Right Arm</label>
           <input type="number" name="system.wear.rightArm.value" value="{{system.wear.rightArm.value}}" data-dtype="Number"/>
         </div>
+        {{/if}}
+        {{#if system.locations.leftLeg}}
         <div class="resource">
           <label class="resource-label">Left Leg</label>
           <input type="number" name="system.wear.leftLeg.value" value="{{system.wear.leftLeg.value}}" data-dtype="Number"/>
         </div>
+        {{/if}}
+        {{#if system.locations.rightLeg}}
         <div class="resource">
           <label class="resource-label">Right Leg</label>
           <input type="number" name="system.wear.rightLeg.value" value="{{system.wear.rightLeg.value}}" data-dtype="Number"/>
         </div>
+        {{/if}}
       </div>
 
       <div class="form-group">

--- a/templates/items/item-sheet.hbs
+++ b/templates/items/item-sheet.hbs
@@ -45,7 +45,7 @@
 
       {{#if (eq item.type "armor")}}
       <div class="form-group">
-        <label>Protection</label>
+        <label>Armor Value</label>
         <input type="number" name="system.protection.value" value="{{system.protection.value}}" data-dtype="Number"/>
       </div>
       <div class="form-group">

--- a/templates/items/weapon-sheet.hbs
+++ b/templates/items/weapon-sheet.hbs
@@ -20,10 +20,6 @@
           <input type="text" name="system.damage.value" value="{{system.damage.value}}" placeholder="e.g., 1d6+2"/>
         </div>
 
-        <div class="resource">
-          <label class="resource-label">Damage Bonus</label>
-          <input type="number" name="system.damage.bonus" value="{{system.damage.bonus}}" data-dtype="Number"/>
-        </div>
 
         <div class="resource">
           <label class="resource-label">Ability Bonus</label>


### PR DESCRIPTION
## Summary
- remove unused damage bonus field from items
- rename protection/defense to Armor Value
- show battle wear inputs only for selected armor locations
- display weapon damage and AV on descendant sheet

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684384475c38832dbc1ec9dc6d100e1c