### PR TITLE
Update armor integrity calculations

### DIFF
--- a/scripts/descendant-sheet.js
+++ b/scripts/descendant-sheet.js
@@ -444,7 +444,21 @@ export class WitchIronDescendantSheet extends ActorSheet {
     event.preventDefault();
     const header = event.currentTarget;
     const type = header.dataset.type || "gear";
-    await createItem(this.actor, type);
+
+    if (type === "injury") {
+      const savedDefaults = game.settings.get("witch-iron", "injurySheetDefaults") || {};
+      const system = {
+        description: "",
+        effect: "",
+        location: "",
+        severity: { value: 1 }
+      };
+      foundry.utils.mergeObject(system, savedDefaults, { inplace: true });
+      const name = savedDefaults.name !== undefined ? savedDefaults.name : "New Injury";
+      await createItem(this.actor, type, { name, img: "icons/svg/blood.svg", system });
+    } else {
+      await createItem(this.actor, type);
+    }
   }
 
   /**

--- a/scripts/hit-location-hud.js
+++ b/scripts/hit-location-hud.js
@@ -108,12 +108,28 @@ export class HitLocationHUD {
       if (this.currentActor && this.currentActor.id === actor.id) {
         this.render(actor);
       }
+      this.refreshInjuryMessages(actor);
     });
 
     Hooks.on('updateItem', (item) => {
       if (this.currentActor && item.actor?.id === this.currentActor.id) {
         this.render(this.currentActor);
       }
+      if (item.actor) this.refreshInjuryMessages(item.actor);
+    });
+
+    Hooks.on('createItem', (item) => {
+      if (this.currentActor && item.actor?.id === this.currentActor.id) {
+        this.render(this.currentActor);
+      }
+      if (item.actor) this.refreshInjuryMessages(item.actor);
+    });
+
+    Hooks.on('deleteItem', (item) => {
+      if (this.currentActor && item.actor?.id === this.currentActor.id) {
+        this.render(this.currentActor);
+      }
+      if (item.actor) this.refreshInjuryMessages(item.actor);
     });
 
     this.updateFromSelection();
@@ -149,8 +165,8 @@ export class HitLocationHUD {
       return;
     }
 
-    const anatomy = actor.system?.anatomy || {};
     const trauma = actor.system?.conditions?.trauma || {};
+    const anatomy = {};
 
     // Calculate per-location soak tooltip text
     const rb = Number(actor.system?.attributes?.robustness?.bonus || 0);
@@ -159,12 +175,15 @@ export class HitLocationHUD {
     const LOCS = ["head","torso","leftArm","rightArm","leftLeg","rightLeg"];
     for (const loc of LOCS) {
       wear[loc] = Number(actor.system?.battleWear?.armor?.[loc]?.value || 0);
-      const locData = anatomy[loc] || {};
-      const soak = Number(locData.soak || 0);
-      const av = Number(locData.armor || 0);
-      const other = soak - rb - (av - wear[loc]);
+      const soak = Number(actor.system?.derived?.locationSoak?.[loc] || 0);
+      const baseAv = actor.type === 'monster'
+        ? Number(actor.system?.derived?.armorBonus || 0)
+        : Number(actor.system?.anatomy?.[loc]?.armor || 0);
+      const av = Math.max(0, baseAv - wear[loc]);
+      const other = soak - rb - av;
       const otherVal = other > 0 ? other : 0;
-      soakTooltips[loc] = `Soak/AV ${soak}/${av}: ${rb} + ${otherVal} + (${av} - ${wear[loc]}) = ${soak}`;
+      anatomy[loc] = { soak, armor: av };
+      soakTooltips[loc] = `Soak/AV ${soak}/${av}: ${rb} + ${otherVal} + (${baseAv} - ${wear[loc]}) = ${soak}`;
     }
 
     const condObj = actor.system?.conditions || {};
@@ -204,5 +223,45 @@ export class HitLocationHUD {
     const data = { actor, selectors: selectorData, anatomy, trauma, conditions, soakTooltips, traumaTooltips };
     const html = await renderTemplate('systems/witch-iron/templates/hud/hit-location-hud.hbs', data);
     this.container.innerHTML = html;
+  }
+
+  /**
+   * Update any injury chat cards that reference this actor
+   * @param {Actor} actor
+   */
+  static refreshInjuryMessages(actor) {
+    const messages = game.messages?.contents || [];
+    for (const msg of messages) {
+      const inj = msg.getFlag('witch-iron', 'injuryData');
+      if (!inj) continue;
+      if (inj.attacker === actor.name || inj.defender === actor.name) {
+        const el = document.querySelector(`.message[data-message-id="${msg.id}"]`);
+        if (!el) continue;
+        if (inj.attacker === actor.name) {
+          const w = actor.system?.battleWear?.weapon?.value || 0;
+          el.querySelectorAll('.attacker-wear .battle-wear-value').forEach(e => e.textContent = w);
+          el.querySelectorAll('.attacker-wear .battle-wear-bonus').forEach(e => e.textContent = w);
+
+          const dmgVal = inj.abilityDmg ?? 3;
+          const eff = actor.system?.derived?.weaponBonusEffective || 0;
+          const grid = el.querySelector('.combat-details .grid-two');
+          const vals = grid?.querySelectorAll('span.value');
+          if (vals && vals[0]) vals[0].textContent = `${dmgVal}(${eff})`;
+        }
+        if (inj.defender === actor.name) {
+          const locMap = { head:'head', torso:'torso', 'left-arm':'leftArm', 'right-arm':'rightArm', 'left-leg':'leftLeg', 'right-leg':'rightLeg' };
+          const locKey = locMap[(inj.location || '').toLowerCase().replace(/\s+/g,'-')] || (inj.location || '').toLowerCase();
+          const aWear = actor.system?.battleWear?.armor?.[locKey]?.value || 0;
+          el.querySelectorAll('.defender-wear .battle-wear-value').forEach(e => e.textContent = aWear);
+          el.querySelectorAll('.defender-wear .battle-wear-bonus').forEach(e => e.textContent = aWear);
+
+          const soakVal = inj.abilitySoak ?? 3;
+          const eff = actor.system?.derived?.armorBonusEffective?.[locKey] || 0;
+          const grid = el.querySelector('.combat-details .grid-two');
+          const vals = grid?.querySelectorAll('span.value');
+          if (vals && vals[1]) vals[1].textContent = `${soakVal}(${eff})`;
+        }
+      }
+    }
   }
 }

--- a/scripts/injury-sheet.js
+++ b/scripts/injury-sheet.js
@@ -183,5 +183,15 @@ export class WitchIronInjurySheet extends ItemSheet {
     }
     // Call original update to persist all form fields
     await super._updateObject(event, formData);
+
+    // Save values as defaults for the next injury
+    const defaults = {
+      name: this.item.name,
+      description: this.item.system.description,
+      effect: this.item.system.effect,
+      location: this.item.system.location,
+      severity: { value: this.item.system.severity?.value || 1 }
+    };
+    await game.settings.set("witch-iron", "injurySheetDefaults", defaults);
   }
-} 
+}

--- a/scripts/item.js
+++ b/scripts/item.js
@@ -233,10 +233,28 @@ export class WitchIronItem extends Item {
     }
 
     await this.actor.update({ "system.flags.isCombatCheck": true });
-    return this.actor.rollSkill(skillName, {
+    const msg = await this.actor.rollSkill(skillName, {
       additionalHits,
       isCombatCheck: true
     });
+
+    // Extract hits from the chat card so we can initiate a quarrel
+    const match = msg?.content?.match(/data-hits="(-?\d+)"/);
+    const hits = match ? parseInt(match[1]) : 0;
+
+    const targets = Array.from(game.user.targets || []);
+    if (game.witchIron?.manualQuarrel && targets.length) {
+      for (const t of targets) {
+        await game.witchIron.manualQuarrel({
+          actorId: this.actor.id,
+          hits,
+          skill: skillName,
+          isCombatCheck: true
+        }, t);
+      }
+    }
+
+    return msg;
   }
 
   /**

--- a/scripts/monster-sheet.js
+++ b/scripts/monster-sheet.js
@@ -1233,18 +1233,18 @@ export class WitchIronMonsterSheet extends ActorSheet {
     });
 
     // Update soak and trauma displays
-    const anatomy = actorData.anatomy || {};
     const trauma = actorData.conditions?.trauma || {};
     const rb = Number(actorData.attributes?.robustness?.bonus || 0);
+    const baseAv = Number(actorData.derived?.armorBonus || 0);
     for (const loc of ARMOR_LOCATIONS) {
         const locEl = html.find(`.location-value.${loc}`);
         if (!locEl.length) continue;
-        const soak = Number(anatomy[loc]?.soak || 0);
-        const av = Number(anatomy[loc]?.armor || 0);
         const wearVal = armorWear[loc];
-        const other = soak - rb - (av - wearVal);
+        const soak = Number(actorData.derived?.locationSoak?.[loc] || 0);
+        const av = Math.max(0, baseAv - wearVal);
+        const other = soak - rb - av;
         const otherVal = other > 0 ? other : 0;
-        locEl.attr('title', `${rb} + ${otherVal} + (${av} - ${wearVal}) = ${soak}`);
+        locEl.attr('title', `${rb} + ${otherVal} + (${baseAv} - ${wearVal}) = ${soak}`);
         locEl.find('.soak').text(soak);
         locEl.find('.armor').text(av);
         const tVal = Number(trauma[loc]?.value || 0);

--- a/styles/injury-card.css
+++ b/styles/injury-card.css
@@ -188,7 +188,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 2px;
+    gap: 4px;
 }
 
 .witch-iron.chat-card.injury-card .battle-wear-value,
@@ -202,12 +202,6 @@
     margin-left: 5px;
 }
 
-.witch-iron.chat-card.injury-card .battle-wear-buttons {
-    display: flex;
-    width: 100%;
-    justify-content: space-between;
-    margin-top: 0.5em;
-}
 
 .witch-iron.chat-card.injury-card .battle-wear-minus, 
 .witch-iron.chat-card.injury-card .battle-wear-plus {

--- a/styles/witch-iron.css
+++ b/styles/witch-iron.css
@@ -3852,6 +3852,14 @@ button.roll-skill:hover {
   pointer-events: auto;
 }
 
+/* Ensure battle-wear controls in equipment list are horizontal */
+.witch-iron.sheet.monster .item-wear .wear-controls,
+.witch-iron.sheet.descendant .item-wear .wear-controls {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
 .witch-iron.sheet.monster .hit-hud .battle-wear-minus,
 .witch-iron.sheet.monster .hit-hud .battle-wear-plus,
 .witch-iron.sheet.descendant .hit-hud .battle-wear-minus,

--- a/templates/chat/injury-message.hbs
+++ b/templates/chat/injury-message.hbs
@@ -56,12 +56,10 @@
                         {{/if}}
                     </div>
                     <div class="battle-wear-box">
-                        <span class="battle-wear-value">{{battleWear.attacker.currentWear}}</span>/<span class="battle-wear-max">{{battleWear.attacker.maxWear}}</span>
-                        <span class="battle-wear-effect">+<span class="battle-wear-bonus">{{battleWear.attacker.currentWear}}</span> Damage</span>
-                    </div>
-                    <div class="battle-wear-buttons">
                         <button class="battle-wear-minus" data-actor="attacker" data-type="weapon" {{#if (gt battleWear.attacker.currentWear 0)}}{{else}}disabled{{/if}}><i class="fas fa-minus"></i></button>
+                        <span class="battle-wear-value">{{battleWear.attacker.currentWear}}</span>/<span class="battle-wear-max">{{battleWear.attacker.maxWear}}</span>
                         <button class="battle-wear-plus" data-actor="attacker" data-type="weapon" {{#if (lt battleWear.attacker.currentWear battleWear.attacker.maxWear)}}{{else}}disabled{{/if}}><i class="fas fa-plus"></i></button>
+                        <span class="battle-wear-effect">+<span class="battle-wear-bonus">{{battleWear.attacker.currentWear}}</span> Damage</span>
                     </div>
                 </div>
                 
@@ -74,12 +72,10 @@
                         {{/if}}
                     </div>
                     <div class="battle-wear-box">
-                        <span class="battle-wear-value">{{battleWear.defender.currentWear}}</span>/<span class="battle-wear-max">{{battleWear.defender.maxWear}}</span>
-                        <span class="battle-wear-effect">+<span class="battle-wear-bonus">{{battleWear.defender.currentWear}}</span>d6 Soak</span>
-                    </div>
-                    <div class="battle-wear-buttons">
                         <button class="battle-wear-minus" data-actor="defender" data-type="armor" {{#if (gt battleWear.defender.currentWear 0)}}{{else}}disabled{{/if}}><i class="fas fa-minus"></i></button>
+                        <span class="battle-wear-value">{{battleWear.defender.currentWear}}</span>/<span class="battle-wear-max">{{battleWear.defender.maxWear}}</span>
                         <button class="battle-wear-plus" data-actor="defender" data-type="armor" {{#if (lt battleWear.defender.currentWear battleWear.defender.maxWear)}}{{else}}disabled{{/if}}><i class="fas fa-plus"></i></button>
+                        <span class="battle-wear-effect">+<span class="battle-wear-bonus">{{battleWear.defender.currentWear}}</span>d6 Soak</span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- refresh HUD armor values using actor data
- recalc injury card damage and soak text when wear changes
- use stored injury defaults when creating new injuries
- remember values when an injury sheet is saved

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68439df23fc8832dbe14889b9b1c212f