### PR TITLE
Add limb loss visuals

### DIFF
--- a/scripts/descendant-sheet.js
+++ b/scripts/descendant-sheet.js
@@ -45,6 +45,34 @@ export class WitchIronDescendantSheet extends ActorSheet {
     // Prepare injuries list
     data.injuries = data.actor.items.filter(it => it.type === 'injury');
 
+    const limbLoss = { leftArm: 0, rightArm: 0, leftLeg: 0, rightLeg: 0 };
+    for (const item of data.injuries) {
+      const effect = (item.system?.effect || '').toLowerCase();
+      const desc = (item.system?.description || '').toLowerCase();
+      const side = desc.includes('left') ? 'left' : desc.includes('right') ? 'right' : null;
+      let amt = 0;
+      let limb = null;
+      if (effect.includes('lost hand') || effect.includes('lost foot')) amt = 0.25;
+      else if (effect.includes('lost forearm') || effect.includes('lost shin')) amt = 0.5;
+      else if (effect.includes('lost arm') || effect.includes('lost leg')) amt = 1;
+      if (amt === 0) continue;
+      if (effect.includes('hand') || effect.includes('forearm') || effect.includes('arm')) limb = 'arm';
+      else if (effect.includes('foot') || effect.includes('shin') || effect.includes('leg')) limb = 'leg';
+      if (!limb) continue;
+      if (side === 'left') {
+        limbLoss[limb === 'arm' ? 'leftArm' : 'leftLeg'] = Math.max(limbLoss[limb === 'arm' ? 'leftArm' : 'leftLeg'], amt);
+      } else if (side === 'right') {
+        limbLoss[limb === 'arm' ? 'rightArm' : 'rightLeg'] = Math.max(limbLoss[limb === 'arm' ? 'rightArm' : 'rightLeg'], amt);
+      } else {
+        const armKey = limb === 'arm' ? ['leftArm','rightArm'] : ['leftLeg','rightLeg'];
+        for (const k of armKey) limbLoss[k] = Math.max(limbLoss[k], amt);
+      }
+    }
+    data.limbLossClass = {};
+    for (const [k,v] of Object.entries(limbLoss)) {
+      data.limbLossClass[k] = v >= 1 ? 'missing-100' : v >= 0.5 ? 'missing-50' : v >= 0.25 ? 'missing-25' : '';
+    }
+
     // Prepare conditions
     data.conditions = {};
     data.currentConditions = [];

--- a/scripts/hit-location.js
+++ b/scripts/hit-location.js
@@ -1611,6 +1611,38 @@ export class HitLocationDialog extends Application {
             const net = Math.max(0, damage - soak);
             locationData[loc] = { soak, armor, net };
         }
+
+        const limbLoss = { leftArm: 0, rightArm: 0, leftLeg: 0, rightLeg: 0 };
+        const defender = game.actors?.getName?.(this.data.defenderName) || null;
+        if (defender) {
+            for (const item of defender.items) {
+                if (item.type !== 'injury') continue;
+                const effect = (item.system?.effect || '').toLowerCase();
+                const desc = (item.system?.description || '').toLowerCase();
+                const side = desc.includes('left') ? 'left' : desc.includes('right') ? 'right' : null;
+                let amt = 0;
+                let limb = null;
+                if (effect.includes('lost hand') || effect.includes('lost foot')) amt = 0.25;
+                else if (effect.includes('lost forearm') || effect.includes('lost shin')) amt = 0.5;
+                else if (effect.includes('lost arm') || effect.includes('lost leg')) amt = 1;
+                if (amt === 0) continue;
+                if (effect.includes('hand') || effect.includes('forearm') || effect.includes('arm')) limb = 'arm';
+                else if (effect.includes('foot') || effect.includes('shin') || effect.includes('leg')) limb = 'leg';
+                if (!limb) continue;
+                if (side === 'left') {
+                    limbLoss[limb === 'arm' ? 'leftArm' : 'leftLeg'] = Math.max(limbLoss[limb === 'arm' ? 'leftArm' : 'leftLeg'], amt);
+                } else if (side === 'right') {
+                    limbLoss[limb === 'arm' ? 'rightArm' : 'rightLeg'] = Math.max(limbLoss[limb === 'arm' ? 'rightArm' : 'rightLeg'], amt);
+                } else {
+                    const armKey = limb === 'arm' ? ['leftArm','rightArm'] : ['leftLeg','rightLeg'];
+                    for (const k of armKey) limbLoss[k] = Math.max(limbLoss[k], amt);
+                }
+            }
+        }
+        const limbLossClass = {};
+        for (const [k,v] of Object.entries(limbLoss)) {
+            limbLossClass[k] = v >= 1 ? 'missing-100' : v >= 0.5 ? 'missing-50' : v >= 0.25 ? 'missing-25' : '';
+        }
         return {
             defenderName: this.data.defenderName || "Target",
             defenderImg: this.defenderImg,
@@ -1618,7 +1650,8 @@ export class HitLocationDialog extends Application {
             netHits: this.netHits,
             damagePreview: damage,
             phase: this.phase,
-            locations: locationData
+            locations: locationData,
+            limbLossClass
         };
     }
 

--- a/scripts/monster-sheet.js
+++ b/scripts/monster-sheet.js
@@ -321,6 +321,34 @@ export class WitchIronMonsterSheet extends ActorSheet {
     // Add items categorized by type
     context.injuries = actorData.items.filter(item => item.type === 'injury');
 
+    const limbLoss = { leftArm: 0, rightArm: 0, leftLeg: 0, rightLeg: 0 };
+    for (const item of context.injuries) {
+      const effect = (item.system?.effect || '').toLowerCase();
+      const desc = (item.system?.description || '').toLowerCase();
+      const side = desc.includes('left') ? 'left' : desc.includes('right') ? 'right' : null;
+      let amt = 0;
+      let limb = null;
+      if (effect.includes('lost hand') || effect.includes('lost foot')) amt = 0.25;
+      else if (effect.includes('lost forearm') || effect.includes('lost shin')) amt = 0.5;
+      else if (effect.includes('lost arm') || effect.includes('lost leg')) amt = 1;
+      if (amt === 0) continue;
+      if (effect.includes('hand') || effect.includes('forearm') || effect.includes('arm')) limb = 'arm';
+      else if (effect.includes('foot') || effect.includes('shin') || effect.includes('leg')) limb = 'leg';
+      if (!limb) continue;
+      if (side === 'left') {
+        limbLoss[limb === 'arm' ? 'leftArm' : 'leftLeg'] = Math.max(limbLoss[limb === 'arm' ? 'leftArm' : 'leftLeg'], amt);
+      } else if (side === 'right') {
+        limbLoss[limb === 'arm' ? 'rightArm' : 'rightLeg'] = Math.max(limbLoss[limb === 'arm' ? 'rightArm' : 'rightLeg'], amt);
+      } else {
+        const armKey = limb === 'arm' ? ['leftArm','rightArm'] : ['leftLeg','rightLeg'];
+        for (const k of armKey) limbLoss[k] = Math.max(limbLoss[k], amt);
+      }
+    }
+    context.limbLossClass = {};
+    for (const [k,v] of Object.entries(limbLoss)) {
+      context.limbLossClass[k] = v >= 1 ? 'missing-100' : v >= 0.5 ? 'missing-50' : v >= 0.25 ? 'missing-25' : '';
+    }
+
     // Hit location data for soak display
     const anatomy = this.actor.system.anatomy || {};
     const trauma = this.actor.system.conditions?.trauma || {};

--- a/styles/hit-location-hud.css
+++ b/styles/hit-location-hud.css
@@ -105,3 +105,22 @@
 .actor-card.active {
   background: var(--color-accent);
 }
+
+/* Limb loss overlay styles */
+.limb-base {
+  stroke: #888;
+  stroke-linecap: round;
+}
+.limb-overlay {
+  stroke: #693731;
+  stroke-linecap: round;
+}
+.limb-overlay.missing-25 {
+  stroke-dasharray: 75 25;
+}
+.limb-overlay.missing-50 {
+  stroke-dasharray: 50 50;
+}
+.limb-overlay.missing-100 {
+  stroke-dasharray: 0 100;
+}

--- a/styles/hit-location.css
+++ b/styles/hit-location.css
@@ -285,3 +285,22 @@
     inset: 0;
     pointer-events: none;
 }
+
+/* Limb loss overlay styles */
+.limb-base {
+    stroke: #888;
+    stroke-linecap: round;
+}
+.limb-overlay {
+    stroke: #693731;
+    stroke-linecap: round;
+}
+.limb-overlay.missing-25 {
+    stroke-dasharray: 75 25;
+}
+.limb-overlay.missing-50 {
+    stroke-dasharray: 50 50;
+}
+.limb-overlay.missing-100 {
+    stroke-dasharray: 0 100;
+}

--- a/templates/actors/descendant-sheet.hbs
+++ b/templates/actors/descendant-sheet.hbs
@@ -845,10 +845,22 @@
                   <svg viewBox="0 0 200 280" xmlns="http://www.w3.org/2000/svg">
                     <path d="M100,50 C120,50 120,60 120,70 L120,110 C120,130 110,140 100,150 C90,140 80,130 80,110 L80,70 C80,60 80,50 100,50Z" fill="#693731" />
                     <circle cx="100" cy="35" r="15" fill="#693731" />
-                    <path d="M80,70 C70,75 55,90 50,110 C45,130 45,140 55,150" stroke="#693731" stroke-width="16" fill="none" />
-                    <path d="M120,70 C130,75 145,90 150,110 C155,130 155,140 145,150" stroke="#693731" stroke-width="16" fill="none" />
-                    <path d="M90,150 C85,170 80,190 75,230" stroke="#693731" stroke-width="15" fill="none" />
-                    <path d="M110,150 C115,170 120,190 125,230" stroke="#693731" stroke-width="15" fill="none" />
+                    <g class="limb left-arm">
+                      <path class="limb-base" d="M80,70 C70,75 55,90 50,110 C45,130 45,140 55,150" stroke-width="16" fill="none" />
+                      <path class="limb-overlay {{limbLossClass.leftArm}}" d="M80,70 C70,75 55,90 50,110 C45,130 45,140 55,150" stroke-width="16" fill="none" pathLength="100" />
+                    </g>
+                    <g class="limb right-arm">
+                      <path class="limb-base" d="M120,70 C130,75 145,90 150,110 C155,130 155,140 145,150" stroke-width="16" fill="none" />
+                      <path class="limb-overlay {{limbLossClass.rightArm}}" d="M120,70 C130,75 145,90 150,110 C155,130 155,140 145,150" stroke-width="16" fill="none" pathLength="100" />
+                    </g>
+                    <g class="limb left-leg">
+                      <path class="limb-base" d="M90,150 C85,170 80,190 75,230" stroke-width="15" fill="none" />
+                      <path class="limb-overlay {{limbLossClass.leftLeg}}" d="M90,150 C85,170 80,190 75,230" stroke-width="15" fill="none" pathLength="100" />
+                    </g>
+                    <g class="limb right-leg">
+                      <path class="limb-base" d="M110,150 C115,170 120,190 125,230" stroke-width="15" fill="none" />
+                      <path class="limb-overlay {{limbLossClass.rightLeg}}" d="M110,150 C115,170 120,190 125,230" stroke-width="15" fill="none" pathLength="100" />
+                    </g>
                   </svg>
                 </div>
                 <div class="layer values-layer">

--- a/templates/actors/monster-sheet.hbs
+++ b/templates/actors/monster-sheet.hbs
@@ -252,10 +252,22 @@
                     <svg viewBox="0 0 200 280" xmlns="http://www.w3.org/2000/svg">
                       <path d="M100,50 C120,50 120,60 120,70 L120,110 C120,130 110,140 100,150 C90,140 80,130 80,110 L80,70 C80,60 80,50 100,50Z" fill="#693731" />
                       <circle cx="100" cy="35" r="15" fill="#693731" />
-                      <path d="M80,70 C70,75 55,90 50,110 C45,130 45,140 55,150" stroke="#693731" stroke-width="16" fill="none" />
-                      <path d="M120,70 C130,75 145,90 150,110 C155,130 155,140 145,150" stroke="#693731" stroke-width="16" fill="none" />
-                      <path d="M90,150 C85,170 80,190 75,230" stroke="#693731" stroke-width="15" fill="none" />
-                      <path d="M110,150 C115,170 120,190 125,230" stroke="#693731" stroke-width="15" fill="none" />
+                      <g class="limb left-arm">
+                        <path class="limb-base" d="M80,70 C70,75 55,90 50,110 C45,130 45,140 55,150" stroke-width="16" fill="none" />
+                        <path class="limb-overlay {{limbLossClass.leftArm}}" d="M80,70 C70,75 55,90 50,110 C45,130 45,140 55,150" stroke-width="16" fill="none" pathLength="100" />
+                      </g>
+                      <g class="limb right-arm">
+                        <path class="limb-base" d="M120,70 C130,75 145,90 150,110 C155,130 155,140 145,150" stroke-width="16" fill="none" />
+                        <path class="limb-overlay {{limbLossClass.rightArm}}" d="M120,70 C130,75 145,90 150,110 C155,130 155,140 145,150" stroke-width="16" fill="none" pathLength="100" />
+                      </g>
+                      <g class="limb left-leg">
+                        <path class="limb-base" d="M90,150 C85,170 80,190 75,230" stroke-width="15" fill="none" />
+                        <path class="limb-overlay {{limbLossClass.leftLeg}}" d="M90,150 C85,170 80,190 75,230" stroke-width="15" fill="none" pathLength="100" />
+                      </g>
+                      <g class="limb right-leg">
+                        <path class="limb-base" d="M110,150 C115,170 120,190 125,230" stroke-width="15" fill="none" />
+                        <path class="limb-overlay {{limbLossClass.rightLeg}}" d="M110,150 C115,170 120,190 125,230" stroke-width="15" fill="none" pathLength="100" />
+                      </g>
                     </svg>
                   </div>
                   <div class="layer values-layer">

--- a/templates/dialogs/hit-location-selector.hbs
+++ b/templates/dialogs/hit-location-selector.hbs
@@ -35,21 +35,35 @@
                 <!-- Head (larger circle) -->
                 <circle cx="100" cy="35" r="15" fill="#693731" class="body-part head-part" data-location="head" />
                 <!-- Arms -->
-                <path d="M80,70
+                <g class="limb left-arm">
+                    <path class="limb-base" d="M80,70
                          C70,75 55,90 50,110
-                         C45,130 45,140 55,150"
-                      stroke="#693731" stroke-width="16" fill="none" class="body-part left-arm-part" data-location="left-arm" />
-                <path d="M120,70
+                         C45,130 45,140 55,150" stroke-width="16" fill="none" />
+                    <path class="limb-overlay {{limbLossClass.leftArm}} body-part left-arm-part" d="M80,70
+                         C70,75 55,90 50,110
+                         C45,130 45,140 55,150" stroke-width="16" fill="none" pathLength="100" data-location="left-arm" />
+                </g>
+                <g class="limb right-arm">
+                    <path class="limb-base" d="M120,70
                          C130,75 145,90 150,110
-                         C155,130 155,140 145,150"
-                      stroke="#693731" stroke-width="16" fill="none" class="body-part right-arm-part" data-location="right-arm" />
+                         C155,130 155,140 145,150" stroke-width="16" fill="none" />
+                    <path class="limb-overlay {{limbLossClass.rightArm}} body-part right-arm-part" d="M120,70
+                         C130,75 145,90 150,110
+                         C155,130 155,140 145,150" stroke-width="16" fill="none" pathLength="100" data-location="right-arm" />
+                </g>
                 <!-- Legs -->
-                <path d="M90,150
-                         C85,170 80,190 75,230"
-                      stroke="#693731" stroke-width="15" fill="none" class="body-part left-leg-part" data-location="left-leg" />
-                <path d="M110,150
-                         C115,170 120,190 125,230"
-                      stroke="#693731" stroke-width="15" fill="none" class="body-part right-leg-part" data-location="right-leg" />
+                <g class="limb left-leg">
+                    <path class="limb-base" d="M90,150
+                         C85,170 80,190 75,230" stroke-width="15" fill="none" />
+                    <path class="limb-overlay {{limbLossClass.leftLeg}} body-part left-leg-part" d="M90,150
+                         C85,170 80,190 75,230" stroke-width="15" fill="none" pathLength="100" data-location="left-leg" />
+                </g>
+                <g class="limb right-leg">
+                    <path class="limb-base" d="M110,150
+                         C115,170 120,190 125,230" stroke-width="15" fill="none" />
+                    <path class="limb-overlay {{limbLossClass.rightLeg}} body-part right-leg-part" d="M110,150
+                         C115,170 120,190 125,230" stroke-width="15" fill="none" pathLength="100" data-location="right-leg" />
+                </g>
             </svg>
         </div>
         <div class="values-layer">

--- a/templates/hud/hit-location-hud.hbs
+++ b/templates/hud/hit-location-hud.hbs
@@ -12,10 +12,22 @@
       <svg viewBox="0 0 200 280" xmlns="http://www.w3.org/2000/svg">
         <path d="M100,50 C120,50 120,60 120,70 L120,110 C120,130 110,140 100,150 C90,140 80,130 80,110 L80,70 C80,60 80,50 100,50Z" fill="#693731" />
         <circle cx="100" cy="35" r="15" fill="#693731" />
-        <path d="M80,70 C70,75 55,90 50,110 C45,130 45,140 55,150" stroke="#693731" stroke-width="16" fill="none" />
-        <path d="M120,70 C130,75 145,90 150,110 C155,130 155,140 145,150" stroke="#693731" stroke-width="16" fill="none" />
-        <path d="M90,150 C85,170 80,190 75,230" stroke="#693731" stroke-width="15" fill="none" />
-        <path d="M110,150 C115,170 120,190 125,230" stroke="#693731" stroke-width="15" fill="none" />
+        <g class="limb left-arm">
+          <path class="limb-base" d="M80,70 C70,75 55,90 50,110 C45,130 45,140 55,150" stroke-width="16" fill="none" />
+          <path class="limb-overlay {{limbLossClass.leftArm}}" d="M80,70 C70,75 55,90 50,110 C45,130 45,140 55,150" stroke-width="16" fill="none" pathLength="100" />
+        </g>
+        <g class="limb right-arm">
+          <path class="limb-base" d="M120,70 C130,75 145,90 150,110 C155,130 155,140 145,150" stroke-width="16" fill="none" />
+          <path class="limb-overlay {{limbLossClass.rightArm}}" d="M120,70 C130,75 145,90 150,110 C155,130 155,140 145,150" stroke-width="16" fill="none" pathLength="100" />
+        </g>
+        <g class="limb left-leg">
+          <path class="limb-base" d="M90,150 C85,170 80,190 75,230" stroke-width="15" fill="none" />
+          <path class="limb-overlay {{limbLossClass.leftLeg}}" d="M90,150 C85,170 80,190 75,230" stroke-width="15" fill="none" pathLength="100" />
+        </g>
+        <g class="limb right-leg">
+          <path class="limb-base" d="M110,150 C115,170 120,190 125,230" stroke-width="15" fill="none" />
+          <path class="limb-overlay {{limbLossClass.rightLeg}}" d="M110,150 C115,170 120,190 125,230" stroke-width="15" fill="none" pathLength="100" />
+        </g>
       </svg>
     </div>
     <div class="layer values-layer">


### PR DESCRIPTION
## Summary
- render lost limbs on token HUD, actor sheets, and location selector
- compute limb loss from injuries
- style limb overlay visuals

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d98e84338832d8ff7a8dfcf6df2b5