### PR TITLE
Fix limb loss detection per side

### DIFF
--- a/scripts/descendant-sheet.js
+++ b/scripts/descendant-sheet.js
@@ -49,7 +49,13 @@ export class WitchIronDescendantSheet extends ActorSheet {
     for (const item of data.injuries) {
       const effect = (item.system?.effect || '').toLowerCase();
       const desc = (item.system?.description || '').toLowerCase();
-      const side = desc.includes('left') ? 'left' : desc.includes('right') ? 'right' : null;
+      const loc = (item.system?.location || '').toLowerCase();
+      const name = (item.name || '').toLowerCase();
+      const side = loc.includes('left') || name.includes('left') || desc.includes('left')
+        ? 'left'
+        : loc.includes('right') || name.includes('right') || desc.includes('right')
+        ? 'right'
+        : null;
       let amt = 0;
       let limb = null;
       if (effect.includes('lost hand') || effect.includes('lost foot')) amt = 0.25;

--- a/scripts/hit-location-hud.js
+++ b/scripts/hit-location-hud.js
@@ -227,7 +227,13 @@ export class HitLocationHUD {
       if (item.type !== 'injury') continue;
       const effect = (item.system?.effect || '').toLowerCase();
       const desc = (item.system?.description || '').toLowerCase();
-      const side = desc.includes('left') ? 'left' : desc.includes('right') ? 'right' : null;
+      const loc = (item.system?.location || '').toLowerCase();
+      const name = (item.name || '').toLowerCase();
+      const side = loc.includes('left') || name.includes('left') || desc.includes('left')
+        ? 'left'
+        : loc.includes('right') || name.includes('right') || desc.includes('right')
+        ? 'right'
+        : null;
       let amt = 0;
       let limb = null;
       if (effect.includes('lost hand') || effect.includes('lost foot')) amt = 0.25;

--- a/scripts/hit-location.js
+++ b/scripts/hit-location.js
@@ -1619,7 +1619,13 @@ export class HitLocationDialog extends Application {
                 if (item.type !== 'injury') continue;
                 const effect = (item.system?.effect || '').toLowerCase();
                 const desc = (item.system?.description || '').toLowerCase();
-                const side = desc.includes('left') ? 'left' : desc.includes('right') ? 'right' : null;
+                const loc = (item.system?.location || '').toLowerCase();
+                const name = (item.name || '').toLowerCase();
+                const side = loc.includes('left') || name.includes('left') || desc.includes('left')
+                    ? 'left'
+                    : loc.includes('right') || name.includes('right') || desc.includes('right')
+                    ? 'right'
+                    : null;
                 let amt = 0;
                 let limb = null;
                 if (effect.includes('lost hand') || effect.includes('lost foot')) amt = 0.25;

--- a/scripts/monster-sheet.js
+++ b/scripts/monster-sheet.js
@@ -325,7 +325,13 @@ export class WitchIronMonsterSheet extends ActorSheet {
     for (const item of context.injuries) {
       const effect = (item.system?.effect || '').toLowerCase();
       const desc = (item.system?.description || '').toLowerCase();
-      const side = desc.includes('left') ? 'left' : desc.includes('right') ? 'right' : null;
+      const loc = (item.system?.location || '').toLowerCase();
+      const name = (item.name || '').toLowerCase();
+      const side = loc.includes('left') || name.includes('left') || desc.includes('left')
+        ? 'left'
+        : loc.includes('right') || name.includes('right') || desc.includes('right')
+        ? 'right'
+        : null;
       let amt = 0;
       let limb = null;
       if (effect.includes('lost hand') || effect.includes('lost foot')) amt = 0.25;


### PR DESCRIPTION
## Summary
- detect side from injury name, description, or location
- apply side-aware limb loss on all actor sheets and hit location HUD

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684db8f02604832dbee95b2c82e0c5a8