### PR TITLE
Refine limb loss side detection

### DIFF
--- a/scripts/descendant-sheet.js
+++ b/scripts/descendant-sheet.js
@@ -49,7 +49,12 @@ export class WitchIronDescendantSheet extends ActorSheet {
     for (const item of data.injuries) {
       const effect = (item.system?.effect || '').toLowerCase();
       const desc = (item.system?.description || '').toLowerCase();
-      const side = desc.includes('left') ? 'left' : desc.includes('right') ? 'right' : null;
+      const name = (item.name || '').toLowerCase();
+      const loc = (item.system?.location || '').toLowerCase();
+      const hasLeft = [loc, name, desc].some(t => t.includes('left'));
+      const hasRight = [loc, name, desc].some(t => t.includes('right'));
+      const side = hasLeft ? 'left' : hasRight ? 'right' : null;
+
       let amt = 0;
       let limb = null;
       if (effect.includes('lost hand') || effect.includes('lost foot')) amt = 0.25;
@@ -59,6 +64,7 @@ export class WitchIronDescendantSheet extends ActorSheet {
       if (effect.includes('hand') || effect.includes('forearm') || effect.includes('arm')) limb = 'arm';
       else if (effect.includes('foot') || effect.includes('shin') || effect.includes('leg')) limb = 'leg';
       if (!limb) continue;
+
       if (side === 'left') {
         limbLoss[limb === 'arm' ? 'leftArm' : 'leftLeg'] = Math.max(limbLoss[limb === 'arm' ? 'leftArm' : 'leftLeg'], amt);
       } else if (side === 'right') {

--- a/scripts/hit-location-hud.js
+++ b/scripts/hit-location-hud.js
@@ -227,7 +227,12 @@ export class HitLocationHUD {
       if (item.type !== 'injury') continue;
       const effect = (item.system?.effect || '').toLowerCase();
       const desc = (item.system?.description || '').toLowerCase();
-      const side = desc.includes('left') ? 'left' : desc.includes('right') ? 'right' : null;
+      const name = (item.name || '').toLowerCase();
+      const loc = (item.system?.location || '').toLowerCase();
+      const hasLeft = [loc, name, desc].some(t => t.includes('left'));
+      const hasRight = [loc, name, desc].some(t => t.includes('right'));
+      const side = hasLeft ? 'left' : hasRight ? 'right' : null;
+
       let amt = 0;
       let limb = null;
       if (effect.includes('lost hand') || effect.includes('lost foot')) amt = 0.25;
@@ -237,6 +242,7 @@ export class HitLocationHUD {
       if (effect.includes('hand') || effect.includes('forearm') || effect.includes('arm')) limb = 'arm';
       else if (effect.includes('foot') || effect.includes('shin') || effect.includes('leg')) limb = 'leg';
       if (!limb) continue;
+
       if (side === 'left') {
         limbLoss[limb === 'arm' ? 'leftArm' : 'leftLeg'] = Math.max(limbLoss[limb === 'arm' ? 'leftArm' : 'leftLeg'], amt);
       } else if (side === 'right') {

--- a/scripts/hit-location.js
+++ b/scripts/hit-location.js
@@ -1619,7 +1619,11 @@ export class HitLocationDialog extends Application {
                 if (item.type !== 'injury') continue;
                 const effect = (item.system?.effect || '').toLowerCase();
                 const desc = (item.system?.description || '').toLowerCase();
-                const side = desc.includes('left') ? 'left' : desc.includes('right') ? 'right' : null;
+                const name = (item.name || '').toLowerCase();
+                const loc = (item.system?.location || '').toLowerCase();
+                const hasLeft = [loc, name, desc].some(t => t.includes('left'));
+                const hasRight = [loc, name, desc].some(t => t.includes('right'));
+                const side = hasLeft ? 'left' : hasRight ? 'right' : null;
                 let amt = 0;
                 let limb = null;
                 if (effect.includes('lost hand') || effect.includes('lost foot')) amt = 0.25;

--- a/scripts/monster-sheet.js
+++ b/scripts/monster-sheet.js
@@ -325,7 +325,11 @@ export class WitchIronMonsterSheet extends ActorSheet {
     for (const item of context.injuries) {
       const effect = (item.system?.effect || '').toLowerCase();
       const desc = (item.system?.description || '').toLowerCase();
-      const side = desc.includes('left') ? 'left' : desc.includes('right') ? 'right' : null;
+      const name = (item.name || '').toLowerCase();
+      const loc = (item.system?.location || '').toLowerCase();
+      const hasLeft = [loc, name, desc].some(t => t.includes('left'));
+      const hasRight = [loc, name, desc].some(t => t.includes('right'));
+      const side = hasLeft ? 'left' : hasRight ? 'right' : null;
       let amt = 0;
       let limb = null;
       if (effect.includes('lost hand') || effect.includes('lost foot')) amt = 0.25;


### PR DESCRIPTION
## Summary
- track limb loss per-side by checking the injury name, description and location

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684db8f02604832dbee95b2c82e0c5a8